### PR TITLE
Disable keyboard control of the font size picker in the toolbar for now

### DIFF
--- a/programs/editor/widgets/simpleStyles.js
+++ b/programs/editor/widgets/simpleStyles.js
@@ -111,9 +111,17 @@ define("webodf/editor/widgets/simpleStyles", [
                 smallDelta: 1,
                 constraints: {min:6, max:96},
                 intermediateChanges: true,
-                onChange: function(value) {
+                onChange: function (value) {
                     directTextStyler.setFontSize(value);
+                },
+                onClick: function () {
                     self.onToolDone();
+                },
+                onInput: function () {
+                    // Do not process any input in the text box;
+                    // even paste events will not be processed
+                    // so that no corrupt values can exist
+                    return false;
                 }
             });
 


### PR DESCRIPTION
This stops handling keyboard input on the font size picker because dojo does not yet afford enough control and we want to not let it steal focus.

This puts a pause on #10 and #11.

The only way to now change the font size is to use the scroll wheel or click on the arrows.
