### PR TITLE
Workaround EditInfo not being cleaned up on resolving of its paragraph, thus failing in its destroy()

### DIFF
--- a/webodf/lib/ops/EditInfo.js
+++ b/webodf/lib/ops/EditInfo.js
@@ -123,7 +123,11 @@ ops.EditInfo = function EditInfo(container, odtDocument) {
      * @return {undefined}
      */
     this.destroy = function(callback) {
-        container.removeChild(editInfoNode);
+        // TODO: have EditInfo cleaned up if the paragraph is deleted, not happening right now
+        // workaround: check if the container is still in the DOM
+        if (container.parentNode) {
+            container.removeChild(editInfoNode);
+        }
         callback();
     };
 

--- a/webodf/lib/ops/OpRemoveText.js
+++ b/webodf/lib/ops/OpRemoveText.js
@@ -224,6 +224,7 @@ ops.OpRemoveText = function OpRemoveText() {
         odtDocument.downgradeWhitespacesAtPosition(position);
         odtDocument.fixCursorPositions();
         odtDocument.getOdfCanvas().refreshSize();
+        // TODO: signal also the deleted paragraphs, so e.g. SessionView can clean up the EditInfo
         odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {
             paragraphElement: destinationParagraph || paragraphElement,
             memberId: memberid,


### PR DESCRIPTION
Was the reason for saving bug in Jos collab demo.
