### PR TITLE
In Style2CSS do not hardcode the fallback for font-family to sans-serif

### DIFF
--- a/webodf/lib/odf/Style2CSS.js
+++ b/webodf/lib/odf/Style2CSS.js
@@ -548,7 +548,8 @@ odf.Style2CSS = function Style2CSS() {
             || props.getAttributeNS(fons, 'font-family');
         if (fontName) {
             value = fontFaceDeclsMap[fontName];
-            rule += 'font-family: ' + (value || fontName) + ', sans-serif;';
+            // TODO: use other information from style:font-face, like style:font-family-generic
+            rule += 'font-family: ' + (value || fontName) + ';';
         }
 
         parentStyle = props.parentNode;


### PR DESCRIPTION
Fixes the sometimes difference in what substitution font is used in the
font selector tool and what substitution font is used in the ODF document
display for fonts which are not installed on the system
Should fix the difference in display as reported in #16 
