### PR TITLE
Drop template draw:frames from the clones of the master pages

### DIFF
--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -423,6 +423,23 @@ odf.OdfCanvas = (function () {
     }
 
     /**
+     * @param {!Node} clonedNode
+     * @return {undefined}
+     */
+    function dropTemplateDrawFrames(clonedNode) {
+        // drop all frames which are just template frames
+        var i, element, presentationClass,
+            clonedDrawFrameElements = clonedNode.getElementsByTagNameNS(drawns, 'frame');
+        for (i = 0; i < clonedDrawFrameElements.length; i += 1) {
+            element = clonedDrawFrameElements[i];
+            presentationClass = element.getAttributeNS(presentationns, 'class');
+            if (presentationClass && ! /^(date-time|footer|header|page-number')$/.test(presentationClass)) {
+                element.parentNode.removeChild(element);
+            }
+        }
+    }
+
+    /**
      * @param {!odf.OdfContainer} odfContainer
      * @param {!string} id
      * @param {!Node} frame
@@ -468,6 +485,8 @@ odf.OdfCanvas = (function () {
                 node = node.nextElementSibling;
                 j += 1;
             }
+            // TODO: above already do not clone nodes which match the rule for being dropped
+            dropTemplateDrawFrames(clonedPage);
 
             // Append the cloned master page to the "Shadow Content" element outside the main ODF dom
             shadowContent.appendChild(clonedPage);


### PR DESCRIPTION
Seems that all draw:frames with the presentation:class attribute other than date-time|footer|header|page-number in the master pages are just there to be copied over to the normal pages/slides.
So they could be simply removed, which then also resulted in all the "Click to edit the outline text format..." to no longer be displayed in the viewer, cmp. http://webodf.org/demo/slides/Viewer.js/#../libreoffice-2013-odfautotests.odp for the current state.

See also ODF 1.2 spec §19.389 presentation:class

Fixes #19 for me
