### PR TITLE
Remove odf.Namespaces.webodfns

### DIFF
--- a/webodf/lib/odf/Namespaces.js
+++ b/webodf/lib/odf/Namespaces.js
@@ -59,7 +59,6 @@ odf.Namespaces = (function () {
         /**@const@type {!string}*/ textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0",
         /**@const@type {!string}*/ xlinkns = 'http://www.w3.org/1999/xlink',
         /**@const@type {!string}*/ xmlns = "http://www.w3.org/XML/1998/namespace",
-        /**@const@type {!string}*/ webodfns = 'urn:webodf',
 
         /** @const@type {!Object.<string,!string>} */
         namespaceMap = {
@@ -78,8 +77,7 @@ odf.Namespaces = (function () {
             "table": tablens,
             "text": textns,
             "xlink": xlinkns,
-            "xml": xmlns,
-            "webodf": webodfns
+            "xml": xmlns
         },
         namespaces;
 
@@ -138,7 +136,6 @@ odf.Namespaces = (function () {
     /**@const@type {!string}*/ namespaces.textns = textns;
     /**@const@type {!string}*/ namespaces.xlinkns = xlinkns;
     /**@const@type {!string}*/ namespaces.xmlns = xmlns;
-    /**@const@type {!string}*/ namespaces.webodfns = webodfns;
 
     return namespaces;
 }());

--- a/webodf/lib/ops/OpAddAnnotation.js
+++ b/webodf/lib/ops/OpAddAnnotation.js
@@ -72,7 +72,7 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
         // Only set the memberid attribute on dc:creator. Let the annotation manager actually set the name
         // for now
         creatorNode = doc.createElementNS(odf.Namespaces.dcns, 'dc:creator');
-        creatorNode.setAttributeNS(odf.Namespaces.webodfns + ':names:editinfo', 'editinfo:memberid', memberid);
+        creatorNode.setAttributeNS('urn:webodf:names:editinfo', 'editinfo:memberid', memberid);
 
         // Date.toISOString return the current Dublin Core representation
         dateNode = doc.createElementNS(odf.Namespaces.dcns, 'dc:date');

--- a/webodf/lib/ops/OpRemoveAnnotation.js
+++ b/webodf/lib/ops/OpRemoveAnnotation.js
@@ -82,7 +82,7 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
         odtDocument.getOdfCanvas().forgetAnnotations();
 
         // Move all cursors - outside and before the annotation node
-        cursors = domUtils.getElementsByTagNameNS(annotationNode, odf.Namespaces.webodfns + ':names:cursor', 'cursor');
+        cursors = domUtils.getElementsByTagNameNS(annotationNode, 'urn:webodf:names:cursor', 'cursor');
         while (cursors.length) {
             annotationNode.parentNode.insertBefore(cursors.pop(), annotationNode);
         }


### PR DESCRIPTION
odf.Namespace.webodfns is not a normal namespace like the other namespaces there, but rather a namespace namespace.

It might make sense to have a (separate) listing of all the webodf namespaces and related prefixes surely.
