### PR TITLE
 	Prevent the backspace key from causing the browser to go back in history

### DIFF
--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -1126,6 +1126,17 @@ gui.SessionController = (function () {
         };
 
         /**
+         * Return the keyboard event handlers
+         * @returns {{keydown: gui.KeyboardHandler, keypress: gui.KeyboardHandler}}
+         */
+        this.getKeyboardHandlers = function() {
+            return {
+                keydown: keyDownHandler,
+                keypress: keyPressHandler
+            };
+        };
+
+        /**
          * @param {!function(!Object=)} callback, passing an error object in case of error
          * @return {undefined}
          */


### PR DESCRIPTION
The recent extraction of text manipulation functions slightly changed the backspace key behaviour. The new interface was only returning true if an operation was generated as a result of the call (aligning with all other public functions on the class). This means however that back-spacing when there is no available positions (e.g., at the beginning of a document) was causing the browser to navigate back a page.
