### PR TITLE
Ensure the tabIndex is reset when the local user's caret is re-added after undo/redo

### DIFF
--- a/webodf/lib/gui/CaretManager.js
+++ b/webodf/lib/gui/CaretManager.js
@@ -191,6 +191,8 @@ gui.CaretManager = function CaretManager(sessionController) {
 
             // wire up the cursor update to caret visibility update
             cursor.handleUpdate = scheduleCaretVisibilityCheck;
+            // Negative tab index still allows focus, but removes accessibility by keyboard
+            getCanvasElement().setAttribute("tabIndex", -1);
             // Pass event focus to the session controller
             sessionController.getEventManager().focus();
         } else {

--- a/webodf/lib/gui/EventManager.js
+++ b/webodf/lib/gui/EventManager.js
@@ -44,7 +44,7 @@
  */
 gui.EventManager = function EventManager(odtDocument) {
     "use strict";
-    var canvasElement,
+    var canvasElement = odtDocument.getOdfCanvas().getElement(),
         window = runtime.getWindow(),
         bindToDirectHandler = {
             // In Safari 6.0.5 (7536.30.1), Using either attachEvent or addEventListener
@@ -208,11 +208,4 @@ gui.EventManager = function EventManager(odtDocument) {
             }
         }
     };
-
-    function init() {
-        canvasElement = odtDocument.getOdfCanvas().getElement();
-        canvasElement.tabIndex = "-1"; // Negative tab index still allows focus, but removes accessibility by keyboard
-    }
-
-    init();
 };


### PR DESCRIPTION
During the recent event & focus refactor, the tab index was being set on
initialisation of the EventManager class, and would then be unset when
the local caret was removed. This meant that no new events would be sent
to WebODF (e.g., typing) after an undo.
