### PR TITLE
Fix shift+click selection extension for reverse selections (FF and older Chrome)

### DIFF
--- a/webodf/lib/core/Cursor.js
+++ b/webodf/lib/core/Cursor.js
@@ -223,6 +223,14 @@ core.Cursor = function Cursor(document, memberId) {
         recentlyModifiedNodes.length = 0;
     };
     /**
+     * Returns if the selection of this cursor has the
+     * same direction as the direction of the range
+     * @return {boolean}
+     */
+    this.hasForwardSelection = function() {
+        return forwardSelection;
+    };
+    /**
      * Remove the cursor from the document tree.
      * @return {undefined}
      */

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -801,13 +801,20 @@ gui.SessionController = (function () {
          */
         function maintainCursorSelection() {
             var cursor = odtDocument.getCursor(inputMemberId),
-                selection = window.getSelection();
+                selection = window.getSelection(),
+                range;
 
+            // May have just processed our own remove cursor operation...
+            // Probably not a good idea to try and update our selected range in this case ;-)
             if (eventManager.hasFocus() && cursor) {
-                // May have just processed our own remove cursor operation...
-                // Probably not a good idea to try and update our selected range in this case ;-)
-                selection.removeAllRanges();
-                selection.addRange(cursor.getSelectedRange().cloneRange());
+                range = cursor.getSelectedRange();
+                if (cursor.hasForwardSelection()) {
+                    selection.collapse(range.startContainer, range.startOffset);
+                    selection.extend(range.endContainer, range.endOffset);
+                } else {
+                    selection.collapse(range.endContainer, range.endOffset);
+                    selection.extend(range.startContainer, range.startOffset);
+                }
             }
         }
 

--- a/webodf/lib/ops/OdtCursor.js
+++ b/webodf/lib/ops/OdtCursor.js
@@ -136,6 +136,14 @@ ops.OdtCursor = function OdtCursor(memberId, odtDocument) {
         return cursor.getSelectedRange();
     };
     /**
+     * Returns if the selection of this cursor has the
+     * same direction as the direction of the range
+     * @return {boolean}
+     */
+    this.hasForwardSelection = function() {
+        return cursor.hasForwardSelection();
+    };
+    /**
      * Obtain the odtDocument to which the cursor corresponds.
      * @return {!ops.OdtDocument}
      */


### PR DESCRIPTION
The selection direction was being lost when the window's current selection
was resynchronised to the cursor selection. For firefox and some versions
of Chrome, this would cause selection extension behaviours (shift+click)
to work incorrectly when attempting to extend the selection to the left
of the caret.

Note, this patch is largely a subset of some changes made in #112 in order to try and keep conflicts as few as possible.
