### PR TITLE
Make the text:line-break elements behave like <br>

### DIFF
--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -693,6 +693,22 @@ odf.OdfCanvas = (function () {
     }
 
     /**
+     * Make the text:line-break elements behave like html br element.
+     * @param {!Element} odffragment
+     * @return {undefined}
+     */
+    function modifyLineBreakElements(odffragment) {
+        var document = odffragment.ownerDocument,
+            lineBreakElements = domUtils.getElementsByTagNameNS(odffragment, textns, "line-break");
+        lineBreakElements.forEach(function (lineBreak) {
+            // Make sure we don't add br more than once as this method is executed whenever user undo an operation.
+            if (!lineBreak.hasChildNodes()) {
+                lineBreak.appendChild(document.createElement("br"));
+            }
+        });
+    }
+
+    /**
      * Expand ODF spaces of the form <text:s text:c=N/> to N consecutive
      * <text:s/> elements. This makes things simpler for WebODF during
      * handling of spaces, in particular during editing.
@@ -1296,6 +1312,7 @@ odf.OdfCanvas = (function () {
             cloneMasterPages(container, shadowContent, odfnode.body, css);
             modifyTables(odfnode.body);
             modifyLinks(odfnode.body);
+            modifyLineBreakElements(odfnode.body);
             expandSpaceElements(odfnode.body);
             expandTabElements(odfnode.body);
             loadImages(container, odfnode.body, css);

--- a/webodf/lib/odf/OdfUtils.js
+++ b/webodf/lib/odf/OdfUtils.js
@@ -132,6 +132,16 @@ odf.OdfUtils = function OdfUtils() {
     };
 
     /**
+     * Determine if the node is a text:line-break element.
+     * @param {?Node} e
+     * @return {!boolean}
+     */
+    this.isLineBreak = function (e) {
+        var name = e && e.localName;
+        return name === "line-break" && e.namespaceURI === textns;
+    };
+
+    /**
      * Determine if the text consists entirely of whitespace characters.
      * At least one whitespace is required.
      * @param {!string} text

--- a/webodf/lib/ops/OpRemoveText.js
+++ b/webodf/lib/ops/OpRemoveText.js
@@ -106,7 +106,9 @@ ops.OpRemoveText = function OpRemoveText() {
          * @returns {!boolean}
          */
         function shouldRemove(node) {
-            return isOdfNode(node) || (node.nodeType === Node.TEXT_NODE && isOdfNode(/** @type {!Node}*/(node.parentNode)));
+            return isOdfNode(node)
+                || (node.localName === "br" && odfUtils.isLineBreak(node.parentNode))
+                || (node.nodeType === Node.TEXT_NODE && isOdfNode(/** @type {!Node}*/(node.parentNode)));
         }
 
         /**

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -461,6 +461,13 @@
   </ops>
   <after><office:text><text:p><text:span>a<text:tab>&#09;</text:tab><c:cursor c:memberId="Bob"/></text:span></text:p></office:text></after>
  </test>
+ <test name="Remove_DeleteLineBreak">
+  <before><office:text><text:p><text:span>a<text:line-break/>b</text:span></text:p></office:text></before>
+  <ops>
+   <op optype="RemoveText" position="0" length="2"/>
+  </ops>
+  <after><office:text><text:p><text:span>b</text:span></text:p></office:text></after>
+ </test>
  <test name="Remove_DeleteImageWithText">
   <before><office:text><text:p><draw:frame draw:name="graphics1" draw:style-name="fr1" text:anchor-type="as-char" svg:width="5cm" svg:height="6cm"><draw:image xlink:href="Pictures/helloworld.jpg" xlink:type="simple" xlink:actuate="onLoad" xlink:show="embed" /></draw:frame><text:span>hello</text:span></text:p></office:text></before>
   <ops>

--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -38,10 +38,6 @@ text|tab {
   display: inline;
   white-space: pre;
 }
-text|line-break {
-  content: " ";
-  display: block;
-}
 text|tracked-changes {
   /*Consumers that do not support change tracking, should ignore changes.*/
   display: none;


### PR DESCRIPTION
Screen shots of before and after the change
![before](https://f.cloud.github.com/assets/5523424/1357835/6affec36-37a6-11e3-8a9a-81f8de36ca10.PNG)
![after](https://f.cloud.github.com/assets/5523424/1357838/7b914ea0-37a6-11e3-963a-e88f67fc53eb.PNG)
