### PR TITLE
Properly destroy all dojo widgets when Tools is destoy()'d

### DIFF
--- a/programs/editor/Tools.js
+++ b/programs/editor/Tools.js
@@ -102,8 +102,18 @@ define("webodf/editor/Tools", [
              * @return {undefined}
              */
             this.destroy = function (callback) {
-                // TODO: investigate what else needs to be done
-                toolbar.destroyRecursive(true);
+                // TODO:
+                // 1. We don't want to use `document`
+                // 2. We would like to avoid deleting all widgets
+                // under document.body because this might interfere with
+                // other apps that use the editor not-in-an-iframe,
+                // but dojo always puts its dialogs below the body,
+                // so this works for now. Perhaps will be obsoleted
+                // once we move to a better widget toolkit
+                var widgets = dijit.findWidgets(document.body);
+                dojo.forEach(widgets, function(w) {
+                    w.destroyRecursive(false);
+                });
                 callback();
             };
 


### PR DESCRIPTION
Proper destruction of the editor widgets requires destroying each widget, not just those that are children of the toolbar.
Subsequent resurrections of the editor in the same window will now not cause trouble with the styles dialog, since there is no leftover dom node that conflicts.
