### PR TITLE
Fixes for cursor "selection creep" when applying styling to a complete paragraph

### DIFF
--- a/webodf/lib/gui/SelectionMover.js
+++ b/webodf/lib/gui/SelectionMover.js
@@ -341,22 +341,6 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
         }
         return stepsFilter2;
     }
- 
-    /**
-     * Return the number of positions moved to pass the requested number of filtered steps.
-     * The return value is always greater than or equal to the number of filtered steps, as
-     * each position can be at most one step (and it may take multiple positions to reach the
-     * next accepted step)
-     * @param {!number} steps
-     * @param {!core.PositionFilter} filter
-     * @return {!number} Number of positions required to move the requested number of filtered steps
-     */
-    function countBackwardSteps(steps, filter) {
-        var iterator = getIteratorAtCursor(),
-            positions = countSteps(iterator, -steps, filter);
-        // Chrome has some entertaining behaviour where it returns "-0" for an answer here...
-        return positions === 0 ? 0 : -positions;
-    }
 
     /**
      * Return the number of positions moved to pass the requested number of filtered steps.
@@ -619,8 +603,6 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
 
     this.getStepCounter = function () {
         return {
-            countForwardSteps: countStepsPublic,
-            countBackwardSteps: countBackwardSteps,
             countSteps: countStepsPublic,
             convertForwardStepsBetweenFilters: convertForwardStepsBetweenFilters,
             convertBackwardStepsBetweenFilters: convertBackwardStepsBetweenFilters,

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -761,7 +761,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
      */
     this.addCursor = function (cursor) {
         runtime.assert(Boolean(cursor), "OdtDocument::addCursor without cursor");
-        var distanceToFirstTextNode = cursor.getStepCounter().countForwardSteps(1, filter),
+        var distanceToFirstTextNode = cursor.getStepCounter().countSteps(1, filter),
             memberid = cursor.getMemberId();
 
         runtime.assert(typeof memberid === "string", "OdtDocument::addCursor has cursor without memberid");

--- a/webodf/lib/ops/OpAddAnnotation.js
+++ b/webodf/lib/ops/OpAddAnnotation.js
@@ -139,16 +139,6 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
         }
     }
 
-    function countSteps(number, stepCounter, positionFilter) {
-        if (number > 0) {
-            return stepCounter.countForwardSteps(number, positionFilter);
-        }
-        if (number < 0) {
-            return -stepCounter.countBackwardSteps(-number, positionFilter);
-        }
-        return 0;
-    }
-
     this.execute = function (odtDocument) {
         var annotation = {},
             positionFilter = odtDocument.getPositionFilter(),
@@ -176,7 +166,7 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
 
         // Move the cursor inside the new annotation
         if (cursor) {
-            stepsToParagraph = countSteps(lengthToMove, cursor.getStepCounter(), positionFilter);
+            stepsToParagraph = cursor.getStepCounter().countSteps(lengthToMove , positionFilter);
             cursor.move(stepsToParagraph);
             cursor.resetSelectionType();
             odtDocument.emit(ops.OdtDocument.signalCursorMoved, cursor);

--- a/webodf/lib/ops/OpMoveCursor.js
+++ b/webodf/lib/ops/OpMoveCursor.js
@@ -55,16 +55,6 @@ ops.OpMoveCursor = function OpMoveCursor() {
         selectionType = data.selectionType || ops.OdtCursor.RangeSelection;
     };
 
-    function countSteps(number, stepCounter, positionFilter) {
-        if (number > 0) {
-            return stepCounter.countForwardSteps(number, positionFilter);
-        }
-        if (number < 0) {
-            return -stepCounter.countBackwardSteps(-number, positionFilter);
-        }
-        return 0;
-    }
-
     // TODO: instead of calling odtDocument.getCursorPosition(...) and calculating the difference
     // get the position directly and reinsert the cursor there
     this.execute = function (odtDocument) {
@@ -81,12 +71,12 @@ ops.OpMoveCursor = function OpMoveCursor() {
         }
 
         stepCounter = cursor.getStepCounter();
-        stepsToSelectionStart = countSteps(number, stepCounter, positionFilter);
+        stepsToSelectionStart = stepCounter.countSteps(number, positionFilter);
         cursor.move(stepsToSelectionStart);
         if (length) {
             // if the length is non-zero (either positive or negative), this indicates that a range of nodes is
             // being selected.
-            stepsToSelectionEnd = countSteps(length, stepCounter, positionFilter);
+            stepsToSelectionEnd = stepCounter.countSteps(length, positionFilter);
             cursor.move(stepsToSelectionEnd, true);
         }
 

--- a/webodf/tests/gui/SelectionMoverTests.js
+++ b/webodf/tests/gui/SelectionMoverTests.js
@@ -140,13 +140,13 @@ gui.SelectionMoverTests = function SelectionMoverTests(runner) {
     function countAndConfirm(xml, n, filter) {
         createDoc(xml);
         var counter = t.mover.getStepCounter(),
-            steps = counter.countForwardSteps(1, filter),
+            steps = counter.countSteps(1, filter),
             sum = 0,
             stepped = 0;
         while (steps > 0) {
             stepped += t.mover.movePointForward(steps);
             sum += steps;
-            steps = counter.countForwardSteps(1, filter);
+            steps = counter.countSteps(1, filter);
         }
         t.totalSteps = counter.countStepsToPosition(t.root, 0,filter);
         r.shouldBe(t, stepped.toString(), (n - 1).toString());

--- a/webodf/tests/ops/OdtCursorTests.js
+++ b/webodf/tests/ops/OdtCursorTests.js
@@ -340,7 +340,7 @@ ops.OdtCursorTests = function OdtCursorTests(runner) {
         t.startContainer = s.startContainer;
         t.text = s.startContainer.data;
 
-        steps = t.counter.countForwardSteps(n, filter);
+        steps = t.counter.countSteps(n, filter);
         r.shouldBe(t, steps.toString(), m.toString());
 
         s = t.cursor.getSelectedRange();
@@ -357,7 +357,7 @@ ops.OdtCursorTests = function OdtCursorTests(runner) {
         t.startContainer = s.startContainer;
         t.text = s.startContainer.data;
 
-        steps = t.counter.countBackwardSteps(n, filter);
+        steps = -t.counter.countSteps(-n, filter);
         r.shouldBe(t, steps.toString(), m.toString());
         s = t.cursor.getSelectedRange();
         t.startOffset2 = s.startOffset;
@@ -399,19 +399,19 @@ ops.OdtCursorTests = function OdtCursorTests(runner) {
         t.counter = t.cursor.getStepCounter();
 
         // move to a valid position
-        steps = t.counter.countForwardSteps(1, filter);
+        steps = t.counter.countSteps(1, filter);
         t.cursor.move(steps);
-        steps = t.counter.countBackwardSteps(1, filter);
+        steps = -t.counter.countSteps(-1, filter);
         t.cursor.move(-steps);
         t.pos = [];
         t.stepsSum = 0;
         t.moveSum = 0;
         for (i = 1; i <= m; i += 1) {
-            steps = t.counter.countForwardSteps(1, filter);
+            steps = t.counter.countSteps(1, filter);
             t.stepsSum += Math.abs(steps);
             t.moveSum += Math.abs(t.cursor.move(steps));
         }
-        r.shouldBe(t, "t.counter.countForwardSteps(1, t.filter)", "0");
+        r.shouldBe(t, "t.counter.countSteps(1, t.filter)", "0");
         r.shouldBe(t, "t.pos.length", m.toString());
         r.shouldBe(t, "t.stepsSum", n.toString());
         r.shouldBe(t, "t.moveSum", n.toString());
@@ -420,11 +420,11 @@ ops.OdtCursorTests = function OdtCursorTests(runner) {
         t.stepsSum = 0;
         t.moveSum = 0;
         for (i = 1; i <= m; i += 1) {
-            steps = t.counter.countBackwardSteps(1, filter);
+            steps = -t.counter.countSteps(-1, filter);
             t.stepsSum += Math.abs(steps);
             t.moveSum += Math.abs(t.cursor.move(-steps));
         }
-        r.shouldBe(t, "t.counter.countBackwardSteps(1, t.filter)", "0");
+        r.shouldBe(t, "t.counter.countSteps(-1, t.filter)", "0");
         r.shouldBe(t, "t.pos.length", m.toString());
         r.shouldBe(t, "t.stepsSum", n.toString());
         r.shouldBe(t, "t.moveSum", n.toString());

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -86,7 +86,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
      */
     function setCursorPosition(stepsToStart, stepsToEnd) {
         var positions;
-        positions = t.counter.countForwardSteps(stepsToStart, t.filter);
+        positions = t.counter.countSteps(stepsToStart, t.filter);
         t.cursor.move(positions, false);
         if (stepsToEnd) {
             positions = t.counter.countSteps(stepsToEnd, t.filter);
@@ -123,7 +123,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             t.result = serializer.writeToString(t.root.firstChild, odf.Namespaces.namespaceMap);
             t.result = t.result.replace(cursorSerialized, "|");
             r.shouldBe(t, "t.result", "t.expected");
-            t.stepsToNextPosition = t.counter.countForwardSteps(1, t.filter);
+            t.stepsToNextPosition = t.counter.countSteps(1, t.filter);
             t.cursor.move(t.stepsToNextPosition, false);
         }
         // Ensure there are no other walkable positions in the document
@@ -137,8 +137,8 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             t.result = serializer.writeToString(t.root.firstChild, odf.Namespaces.namespaceMap);
             t.result = t.result.replace(cursorSerialized, "|");
             r.shouldBe(t, "t.result", "t.expected");
-            t.stepsToNextPosition = t.counter.countBackwardSteps(1, t.filter);
-            t.cursor.move(-t.stepsToNextPosition, false);
+            t.stepsToNextPosition = t.counter.countSteps(-1, t.filter);
+            t.cursor.move(t.stepsToNextPosition, false);
         }
         // Ensure there are no other walkable positions in the document
         r.shouldBe(t, "t.stepsToNextPosition", "0");


### PR DESCRIPTION
Reproduction steps:
1) Open http://ci.kogmbh.com/deploy/WebODF/webodf-ci-b23-g163c84d5/editor/localeditor.html
2) Click to the left of the second heading ("It can embed fonts too!")
3) Click and drag the selection to the right of the heading (to select the complete heading)
4) Now click the bold button a few times and notice the selection expanding
