### PR TITLE
Added todo to find frame anchor-types from the style tree

### DIFF
--- a/webodf/lib/odf/OdfUtils.js
+++ b/webodf/lib/odf/OdfUtils.js
@@ -70,6 +70,7 @@ odf.OdfUtils = function OdfUtils() {
      */
     function isCharacterFrame(e) {
         var name = e && e.localName;
+        // TODO the anchor-type can be defined on any style associated with the frame
         return name === "frame" && e.namespaceURI === drawns && e.getAttributeNS(textns, "anchor-type") === "as-char";
     }
     this.isCharacterFrame = isCharacterFrame;

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -493,8 +493,14 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
         testCursorPositions("<text:p>|A|<text:s> </text:s>|B|C|</text:p>");
         // Unexpanded spaces - Not really supported, but interesting to test
         testCursorPositions("<text:p>|A|<text:s></text:s>|B|C|</text:p>");
+        // Slight span nesting and positioning
+        testCursorPositions("<text:p><text:span>|<text:s> </text:s>|</text:span></text:p>");
         // TODO behaviour is different from README_cursorpositions
         // cursorPositionsTest("<text:p> <text:span>|A| |</text:span> <text:s></text:s>| <text:span><text:s> </text:s>|B|</text:span> </text:p>");
+    }
+    function testAvailablePositions_DrawElements() {
+        testCursorPositions("<text:p>|<draw:frame text:anchor-type=\"as-char\"><draw:image><office:binary-data>data</office:binary-data></draw:image></draw:frame>|</text:p>");
+        testCursorPositions("<text:p><text:span>|<draw:frame text:anchor-type=\"as-char\"><draw:image><office:binary-data>data</office:binary-data></draw:image></draw:frame>|</text:span></text:p>");
     }
     function testAvailablePositions_Annotations() {
         testCursorPositions('<text:p>|a|b|<office:annotation><text:list><text:list-item><text:p>|</text:p></text:list-item></text:list></office:annotation>c|d|<office:annotation-end></office:annotation-end>1|2|</text:p>');
@@ -563,6 +569,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             testAvailablePositions_MixedSpans,
             testAvailablePositions_Whitespace,
             testAvailablePositions_SpaceElements,
+            testAvailablePositions_DrawElements,
             testAvailablePositions_Annotations
         ];
     };

--- a/webodf/tests/ops/allowedpositions.xml
+++ b/webodf/tests/ops/allowedpositions.xml
@@ -1,4 +1,8 @@
-<tests xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:c="urn:webodf:names:cursor">
+<tests
+    xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+    xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+    xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+    xmlns:c="urn:webodf:names:cursor">
  <test name="MoveCursor00">
   <before><office:text><text:p>ab</text:p><text:p/></office:text></before>
   <ops>
@@ -303,5 +307,21 @@
    <op optype="AddCursor" memberid="Joe"/>
   </ops>
   <after><office:text><text:tracked-changes><text:changed-region><text:deletion><text:p>123</text:p></text:deletion></text:changed-region></text:tracked-changes><text:p><c:cursor c:memberId="Joe"/>ab</text:p><text:p/></office:text></after>
+ </test>
+ <test name="MoveCursor_OverImageAnchoredAsChar">
+  <before>
+   <office:text>
+    <text:p><draw:frame text:anchor-type="as-char"/></text:p>
+   </office:text>
+  </before>
+  <ops>
+   <op optype="AddCursor" memberid="Joe"/>
+   <op optype="MoveCursor" memberid="Joe" position="1"/>
+  </ops>
+  <after>
+   <office:text>
+    <text:p><draw:frame text:anchor-type="as-char"/><c:cursor c:memberId="Joe"/></text:p>
+   </office:text>
+  </after>
  </test>
 </tests>

--- a/webodf/tests/ops/failingtests.xml
+++ b/webodf/tests/ops/failingtests.xml
@@ -1,4 +1,9 @@
-<tests xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:c="urn:webodf:names:cursor">
+<tests
+    xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+    xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+    xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+    xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+    xmlns:c="urn:webodf:names:cursor">
  <test name="AddAnnotationInsertText_startPosSameAtStartOfParagraph">
   <!-- text inserted at the position of a start of an annotation at the start of a paragraph should be added to the annotated area -->
   <before><office:text><text:p>abcd</text:p></office:text></before>
@@ -20,5 +25,31 @@
    <op optype="SplitParagraph" memberid="Bob" position="5"/>
   </ops>
   <after><office:text><text:p><text:span text:style-name="bold">hello</text:span></text:p><text:p><text:span text:style-name="bold"><c:cursor c:memberId="Bob"/></text:span></text:p></office:text></after>
+ </test>
+  <test name="MoveCursor_OverImageAnchoredAsCharInStyle">
+  <before>
+   <office:automatic-styles>
+    <style:style style:name="Graphics" style:family="graphic">
+     <style:graphic-properties text:anchor-type="as-char"/>
+    </style:style>
+   </office:automatic-styles>
+   <office:text>
+    <text:p><draw:frame draw:style-name="Graphics"/></text:p>
+   </office:text>
+  </before>
+  <ops>
+   <op optype="AddCursor" memberid="Joe"/>
+   <op optype="MoveCursor" memberid="Joe" position="1"/>
+  </ops>
+  <after>
+   <office:automatic-styles>
+    <style:style style:name="Graphics" style:family="graphic">
+     <style:graphic-properties text:anchor-type="as-char"/>
+    </style:style>
+   </office:automatic-styles>
+   <office:text>
+    <text:p><draw:frame draw:style-name="Graphics"/><c:cursor c:memberId="Joe"/></text:p>
+   </office:text>
+  </after>
  </test>
 </tests>

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -1049,7 +1049,7 @@
    <office:automatic-styles/>
    <office:text>
     <text:p><text:span>A</text:span></text:p>
-    <text:p><text:span><draw:frame><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p>
+    <text:p><text:span><draw:frame text:anchor-type="as-char"><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p>
     <text:p><text:span>B</text:span></text:p>
    </office:text>
   </before>
@@ -1062,7 +1062,7 @@
    <office:automatic-styles><style:style style:name="auto63350368_0" wo:scope="document-content" style:family="text"><style:text-properties fo:font-weight="bold"/></style:style></office:automatic-styles>
    <office:text>
     <text:p><text:span text:style-name="auto63350368_0">A</text:span></text:p>
-    <text:p><text:span><draw:frame><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p>
+    <text:p><text:span><draw:frame text:anchor-type="as-char"><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p>
     <text:p><text:span text:style-name="auto63350368_0">B</text:span></text:p>
    </office:text>
   </after>
@@ -1070,7 +1070,7 @@
  <test name="ApplyDirectStyling_AroundImage_WithNoWhitespace">
   <before>
    <office:automatic-styles/>
-   <office:text><text:p><text:span>A</text:span></text:p><text:p><text:span><draw:frame><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p><text:p><text:span>B</text:span></text:p></office:text>
+   <office:text><text:p><text:span>A</text:span></text:p><text:p><text:span><draw:frame text:anchor-type="as-char"><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p><text:p><text:span>B</text:span></text:p></office:text>
   </before>
   <ops>
    <op optype="ApplyDirectStyling" memberid="Alice" position="0" length="5">
@@ -1079,7 +1079,7 @@
   </ops>
   <after>
    <office:automatic-styles><style:style style:name="auto63350368_0" wo:scope="document-content" style:family="text"><style:text-properties fo:font-weight="bold"/></style:style></office:automatic-styles>
-   <office:text><text:p><text:span text:style-name="auto63350368_0">A</text:span></text:p><text:p><text:span><draw:frame><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p><text:p><text:span text:style-name="auto63350368_0">B</text:span></text:p></office:text>
+   <office:text><text:p><text:span text:style-name="auto63350368_0">A</text:span></text:p><text:p><text:span><draw:frame text:anchor-type="as-char"><draw:image><office:binary-data>fake inline image</office:binary-data></draw:image></draw:frame></text:span></text:p><text:p><text:span text:style-name="auto63350368_0">B</text:span></text:p></office:text>
   </after>
  </test>
  <test name="ApplyDirectStyling_WithinNonSpanContainer">


### PR DESCRIPTION
Frames that have no direct anchor-type specified currently have incorrect
behaviour, as these default to not behaving as character frames. The
correct behaviour is to actually examine the style inheritance hierarchy
to find the parent style that sets the default.
