### PR TITLE
Have dedicated Editor.closeDocument and Editor.closeSession

### DIFF
--- a/programs/editor/EditorSession.js
+++ b/programs/editor/EditorSession.js
@@ -512,28 +512,6 @@ define("webodf/editor/EditorSession", [
             self.sessionController.getTextManipulator().removeCurrentSelection();
             self.sessionController.getImageManager().insertImage(mimetype, content, width, height);
         };
-        /**
-         * @param {!function(!Object=)} callback, passing an error object in case of error
-         * @return {undefined}
-         */
-        this.close = function (callback) {
-            callback();
-            /*
-            self.sessionView.close(function(err) {
-                if (err) {
-                    callback(err);
-                } else {
-                    caretManager.close(function(err) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            self.sessionController.close(callback);
-                        }
-                    });
-                }
-            });
-            */
-        };
 
         /**
          * @param {!function(!Object=)} callback, passing an error object in case of error

--- a/programs/editor/collabeditor.js
+++ b/programs/editor/collabeditor.js
@@ -145,7 +145,7 @@ var webodfEditor = (function () {
                                 editorOptions.networkSecurityToken = token;
                                 editorOptions.closeCallback = function() {
                                     editorInstance.endEditing();
-                                    editorInstance.close(function() {
+                                    editorInstance.closeSession(function() {
                                         server.leaveSession(sessionId, memberId, function() {
                                             showSessions();
                                         });

--- a/programs/editor/localeditor.js
+++ b/programs/editor/localeditor.js
@@ -105,7 +105,7 @@ var webodfEditor = (function () {
         }
         if (files && files.length === 1) {
             editorInstance.endEditing();
-            editorInstance.close(function() {
+            editorInstance.closeDocument(function() {
                 file = files[0];
                 reader = new FileReader();
                 reader.onloadend = onLoadEnd;


### PR DESCRIPTION
Have dedicated Editor.closeDocument and Editor.closeSession methods to correspond to openDocument and openSession. Remove unused EditorSession.close method, not sure what it was used for.

Upcoming changes in the next PR will further change these two methods to be even more different when I introduce  `OpAddMember` and `OpRemoveMember`.
