### PR TITLE
Disable JSCoverage and it's building in OS X.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ if(WIN32)
         TEST_COMMAND ""
     )
     set(JSCOVERAGE ${CMAKE_BINARY_DIR}/JSCoverage-prefix/src/JSCoverage/jscoverage)
-else(WIN32)
+elseif(APPLE)
+else()
     ExternalProject_Add(
         JSCoverage
         DOWNLOAD_DIR ${EXTERNALS_DOWNLOAD_DIR}
@@ -186,7 +187,7 @@ else(WIN32)
         INSTALL_COMMAND ""
     )
     set(JSCOVERAGE ${CMAKE_BINARY_DIR}/JSCoverage-prefix/src/JSCoverage/jscoverage)
-endif(WIN32)
+endif()
 
 # Dojo
 ExternalProject_Add(

--- a/webodf/CMakeLists.txt
+++ b/webodf/CMakeLists.txt
@@ -185,15 +185,17 @@ if (Java_JAVA_EXECUTABLE)
 
 endif (Java_JAVA_EXECUTABLE)
 
-add_custom_command(
-    OUTPUT instrumented/index.html
-    COMMAND ${JSCOVERAGE}
-    ARGS --exclude=node_modules
-         ${CMAKE_CURRENT_SOURCE_DIR}
-         ${CMAKE_CURRENT_BINARY_DIR}/instrumented
-    DEPENDS ${LIBJSFILES} jslintcheck JSCoverage
-)
-add_custom_target(instrumented ALL DEPENDS instrumented/index.html)
+if (NOT APPLE)
+    add_custom_command(
+        OUTPUT instrumented/index.html
+        COMMAND ${JSCOVERAGE}
+        ARGS --exclude=node_modules
+             ${CMAKE_CURRENT_SOURCE_DIR}
+             ${CMAKE_CURRENT_BINARY_DIR}/instrumented
+        DEPENDS ${LIBJSFILES} jslintcheck JSCoverage
+    )
+    add_custom_target(instrumented ALL DEPENDS instrumented/index.html)
+endif(NOT APPLE)
 
 add_subdirectory(tests)
 


### PR DESCRIPTION
The development toolchain that comes with Mavericks
does not play well with compiling JSCoverage -- which is
unmaintained anyway.

Till we move to a better test coverage tool, we should
disable it therefore people on OS X can compile WebODF.
