### PR TITLE
Allow for sub-pixel rounding in client rects when detecting unscaled ranges

### DIFF
--- a/webodf/lib/core/DomUtils.js
+++ b/webodf/lib/core/DomUtils.js
@@ -81,10 +81,12 @@
 
                 testElement.appendChild(document.createTextNode("Rect transform test"));
                 directBoundingRect = testElement.getBoundingClientRect();
-                rangeBoundingRect = range.getClientRects()[0];
+                rangeBoundingRect = range.getBoundingClientRect();
                 // Firefox doesn't apply parent css transforms to any range client rectangles
                 // See https://bugzilla.mozilla.org/show_bug.cgi?id=863618
-                browserQuirks.unscaledRangeClientRects = directBoundingRect.height !== rangeBoundingRect.height;
+                // Depending on the browser, client rects can sometimes have sub-pixel rounding effects, so
+                // add some wiggle room for this. The scale is 200%, so there is no issues with false positives here
+                browserQuirks.unscaledRangeClientRects = Math.abs(directBoundingRect.height - rangeBoundingRect.height) > 2;
                 range.detach();
 
                 document.body.removeChild(testContainer);


### PR DESCRIPTION
This was causing selection overbleed when selecting a paragraph that had an annotation.
