### PR TITLE
Treat the first space text character after a text:tab as significant whitespace

### DIFF
--- a/webodf/lib/odf/OdfUtils.js
+++ b/webodf/lib/odf/OdfUtils.js
@@ -191,23 +191,23 @@ odf.OdfUtils = function OdfUtils() {
     }
     this.isCharacterElement = isCharacterElement;
     /**
-     * Determine if the node is a whitespace character element.
+     * Determine if the node is a <text:s/> character element.
      * @param {?Node} e
      * @return {!boolean}
      */
-    function isWhitespaceElement(e) {
+    function isSpaceElement(e) {
         var n = e && e.localName,
             ns,
             r = false;
         if (n) {
             ns = e.namespaceURI;
             if (ns === textns) {
-                r = n === "s" || n === "tab";
+                r = n === "s";
             }
         }
         return r;
     }
-    this.isWhitespaceElement = isWhitespaceElement;
+    this.isSpaceElement = isSpaceElement;
     /**
      * @param {!Node} node
      * @return {!Node}
@@ -255,12 +255,13 @@ odf.OdfUtils = function OdfUtils() {
 
     /**
      * Walk to the left along the DOM and return true if the first thing
-     * encountered is either a non-whitespace character or a non-whitespace
-     * character element. Walking goes through grouping elements.
+     * encountered is either a non-whitespace text character or a non-space
+     * character element (i.e., any character element other than <text:s/>).
+     * Walking goes through grouping elements.
      * @param {?Node} node the first node to scan
      * @return {!boolean}
      */
-    function scanLeftForNonWhitespace(node) {
+    function scanLeftForNonSpace(node) {
         var r = false;
         while (node) {
             if (node.nodeType === Node.TEXT_NODE) {
@@ -272,7 +273,7 @@ odf.OdfUtils = function OdfUtils() {
                     );
                 }
             } else if (isCharacterElement(node)) {
-                r = isWhitespaceElement(node) === false;
+                r = isSpaceElement(node) === false;
                 node = null;
             } else {
                 node = previousNode(node);
@@ -280,7 +281,7 @@ odf.OdfUtils = function OdfUtils() {
         }
         return r;
     }
-    this.scanLeftForNonWhitespace = scanLeftForNonWhitespace;
+    this.scanLeftForNonSpace = scanLeftForNonSpace;
     /**
      * Walk to the left along the DOM and return the type of the first
      * thing encountered.
@@ -299,7 +300,7 @@ odf.OdfUtils = function OdfUtils() {
             if (!isODFWhitespace(text.substr(text.length - 1, 1))) {
                 r = 1; // character found
             } else if (text.length === 1) {
-                r = scanLeftForNonWhitespace(previousNode(node)) ? 2 : 0;
+                r = scanLeftForNonSpace(previousNode(node)) ? 2 : 0;
             } else {
                 r = isODFWhitespace(text.substr(text.length - 2, 1)) ? 0 : 2;
             }
@@ -426,7 +427,7 @@ odf.OdfUtils = function OdfUtils() {
                 // First whitespace after a character is significant
                 result = true;
             }
-        } else if (scanLeftForNonWhitespace(previousNode(textNode))) {
+        } else if (scanLeftForNonSpace(previousNode(textNode))) {
             // If the first character found scanning to the left is non-whitespace, this might still be significant
             result = true;
         }
@@ -449,7 +450,7 @@ odf.OdfUtils = function OdfUtils() {
      */
     this.isDowngradableSpaceElement = function(node) {
         if (node.namespaceURI === textns && node.localName === "s") {
-            return scanLeftForNonWhitespace(previousNode(node)) && scanRightForAnyCharacter(nextNode(node));
+            return scanLeftForNonSpace(previousNode(node)) && scanRightForAnyCharacter(nextNode(node));
         }
         return false;
     };

--- a/webodf/lib/ops/TextPositionFilter.js
+++ b/webodf/lib/ops/TextPositionFilter.js
@@ -150,9 +150,9 @@ ops.TextPositionFilter = function TextPositionFilter(getRootNode) {
                     }
                 } else {
                     // check if there is a non-whitespace character or
-                    // character element in a preceding node
+                    // character element (other than text:s) in a preceding node
                     leftNode = odfUtils.previousNode(container);
-                    if (odfUtils.scanLeftForNonWhitespace(leftNode)) {
+                    if (odfUtils.scanLeftForNonSpace(leftNode)) {
                         r = FILTER_ACCEPT;
                     }
                 }

--- a/webodf/tests/odf/OdfUtilsTests.js
+++ b/webodf/tests/odf/OdfUtilsTests.js
@@ -233,6 +233,12 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
 
         r.shouldBe(t, "t.isDowngradable", "true");
     }
+    function isDowngradableWhitespace_DowngradesFirstSpaceAfterTab() {
+        t.doc = createDocument("<text:p><text:tab>  </text:tab><text:s> </text:s>b</text:p>");
+        t.isDowngradable = t.odfUtils.isDowngradableSpaceElement(t.doc.childNodes[1]);
+
+        r.shouldBe(t, "t.isDowngradable", "true");
+    }
     function isDowngradableWhitespace_DoesNotDowngradeTrailingSpace() {
         t.doc = createDocument("<text:p>a<text:s> </text:s></text:p>");
         t.isDowngradable = t.odfUtils.isDowngradableSpaceElement(t.doc.childNodes[1]);
@@ -271,6 +277,7 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
             getImageElements_ReturnTwoImages,
 
             isDowngradableWhitespace_DowngradesFirstSpaceAfterChar,
+            isDowngradableWhitespace_DowngradesFirstSpaceAfterTab,
             isDowngradableWhitespace_DoesNotDowngradeTrailingSpace,
             isDowngradableWhitespace_DoesNotDowngradeLeading,
             isDowngradableWhitespace_DoesNotDowngradeAfterSpace

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -500,6 +500,9 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
         testCursorPositions("<text:p><text:span>|<text:s> </text:s>|</text:span></text:p>");
         // TODO behaviour is different from README_cursorpositions
         // cursorPositionsTest("<text:p> <text:span>|A| |</text:span> <text:s></text:s>| <text:span><text:s> </text:s>|B|</text:span> </text:p>");
+        testCursorPositions("<text:p>|<text:tab>    </text:tab>|<text:s> </text:s>|<text:s> </text:s>|</text:p>");
+        testCursorPositions("<text:p>|<text:tab>    </text:tab>| |<text:s> </text:s>|</text:p>");
+        testCursorPositions("<text:p>|a| | <text:s> </text:s>|   </text:p>");
     }
     function testAvailablePositions_DrawElements() {
         testCursorPositions("<text:p>|<draw:frame text:anchor-type=\"as-char\"><draw:image><office:binary-data>data</office:binary-data></draw:image></draw:frame>|</text:p>");

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -172,7 +172,6 @@
   </ops>
   <after><office:text><text:p>a b</text:p></office:text></after>
  </test>
-
  <test name="InsertText_withSameCursor_AfterSpace2">
   <before><office:text><text:p>a<text:s> </text:s></text:p><text:p/></office:text></before>
   <ops>
@@ -287,6 +286,17 @@
    <op optype="InsertText" position="3" text="c"/>
   </ops>
   <after><office:text><text:p>a bc</text:p></office:text></after>
+ </test>
+ <test name="InsertText_AfterSpaceAndTab_InNewParagraph">
+  <before><office:text><text:p/></office:text></before>
+  <ops>
+   <op optype="SplitParagraph" position="0"/>
+   <op optype="InsertText" position="1" text="&#x9;  "/>
+   <op optype="SplitParagraph" position="4"/>
+   <op optype="InsertText" position="5" text="U"/>
+   <op optype="RemoveText" position="0" length="1"/>
+  </ops>
+  <after><office:text><text:p><text:tab>&#x9;</text:tab> <text:s> </text:s></text:p><text:p>U</text:p></office:text></after>
  </test>
  <test name="RemoveSpace">
   <before><office:text><text:p><text:s> </text:s></text:p></office:text></before>


### PR DESCRIPTION
A space character is considered significant when it follows either a non-space character element (e.g., text:tab), or a non-space character.

From the ODF specs (6.1.3, text:s/):
This element shall be used to represent the second and all following “ “ (U+0020, SPACE) characters in a sequence of “ “ (U+0020, SPACE) characters.

Failure to do this properly causes some strange text insertion behaviour and a crash when pasting to the end of a document.

Reproduction steps (note, copy & paste only work properly in Chrome):
1. Open the editor (http://ci.kogmbh.com/deploy/WebODF/webodf-ci-b84-g48f62e2d/editor/localeditor.html)
2. Remove all content (including annotations) from the document
3. In the now-blank document, type a tab character followed by 2 spaces, a line break, and a letter (i.e., "\t  \nW")
4. Select the entire document
5. Copy this to the clipboard
6. Remove all content
7. Paste the content into the blank document. Observe the uncaught exception "Cannot call method 'getElementsByTagNameNS' of null"
