### PR TITLE
Add isEdit properties to all operation classes

### DIFF
--- a/programs/editor/server/pullbox/OperationRouter.js
+++ b/programs/editor/server/pullbox/OperationRouter.js
@@ -410,8 +410,8 @@ runtime.log("OperationRouter: instant opsSync requested");
                 var timedOp,
                     opspec = op.spec();
 
-                // note if any local ops modified TODO: find less fragile way, perhaps have the operationFactory check it?
-                hasPushedModificationOps = hasPushedModificationOps || !/^(AddCursor|MoveCursor|RemoveCursor)$/.test(opspec.optype);
+                // note if any local ops modified 
+                hasPushedModificationOps = hasPushedModificationOps || op.isEdit;
 
                 // apply locally
                 opspec.timestamp = (new Date()).getTime();

--- a/webodf/lib/gui/UndoStateRules.js
+++ b/webodf/lib/gui/UndoStateRules.js
@@ -63,20 +63,12 @@ gui.UndoStateRules = function UndoStateRules() {
 
     /**
      * Returns true if the supplied operation
-     * is considered an editing operation from the perspective
-     * of undo/redo behaviour.
+     * is considered an editing operation.
      * @param {ops.Operation} op
      * @returns {boolean} Returns true if the supplied op is an edit operation
      */
     function isEditOperation(op) {
-        switch (getOpType(op)) {
-            case "MoveCursor":
-            case "AddCursor":
-            case "RemoveCursor":
-                return false;
-            default:
-                return true;
-        }
+        return op.isEdit;
     }
     this.isEditOperation = isEditOperation;
 

--- a/webodf/lib/ops/OpAddAnnotation.js
+++ b/webodf/lib/ops/OpAddAnnotation.js
@@ -55,6 +55,8 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
         name = data.name;
     };
 
+    this.isEdit = true;
+
     /**
      * Creates an office:annotation node with a dc:creator, dc:date, and a paragraph wrapped within
      * a list, inside it; and with the given annotation name

--- a/webodf/lib/ops/OpAddCursor.js
+++ b/webodf/lib/ops/OpAddCursor.js
@@ -52,6 +52,8 @@ ops.OpAddCursor = function OpAddCursor() {
         timestamp = data.timestamp;
     };
 
+    this.isEdit = false;
+
     this.execute = function (odtDocument) {
         var cursor = odtDocument.getCursor(memberid);
 

--- a/webodf/lib/ops/OpAddMember.js
+++ b/webodf/lib/ops/OpAddMember.js
@@ -48,6 +48,8 @@ ops.OpAddMember = function OpAddMember() {
         setProperties = data.setProperties;
     };
 
+    this.isEdit = false;
+
     this.execute = function (odtDocument) {
         if (odtDocument.getMember(memberid)) {
             return false;

--- a/webodf/lib/ops/OpAddStyle.js
+++ b/webodf/lib/ops/OpAddStyle.js
@@ -64,6 +64,8 @@ ops.OpAddStyle = function OpAddStyle() {
         setProperties = data.setProperties;
      };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         var odfContainer = odtDocument.getOdfCanvas().odfContainer(),
             formatting = odtDocument.getFormatting(),

--- a/webodf/lib/ops/OpApplyDirectStyling.js
+++ b/webodf/lib/ops/OpApplyDirectStyling.js
@@ -64,6 +64,8 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
         setProperties = data.setProperties;
     };
 
+    this.isEdit = true;
+
     function getRange(odtDocument) {
         var point1 = length >= 0 ? position : position + length,
             point2 = length >= 0 ? position + length : position,

--- a/webodf/lib/ops/OpInsertImage.js
+++ b/webodf/lib/ops/OpInsertImage.js
@@ -62,6 +62,8 @@ ops.OpInsertImage = function OpInsertImage() {
         frameName = data.frameName;
     };
 
+    this.isEdit = true;
+
     /**
      * @param document
      * @returns {!Element}

--- a/webodf/lib/ops/OpInsertTable.js
+++ b/webodf/lib/ops/OpInsertTable.js
@@ -62,6 +62,8 @@ ops.OpInsertTable = function OpInsertTable() {
         tableCellStyleMatrix = data.tableCellStyleMatrix;
     };
 
+    this.isEdit = true;
+
     /**
      * @param {!number} row
      * @param {!number} column

--- a/webodf/lib/ops/OpInsertText.js
+++ b/webodf/lib/ops/OpInsertText.js
@@ -56,6 +56,8 @@ ops.OpInsertText = function OpInsertText() {
         text = data.text;
     };
 
+    this.isEdit = true;
+
     /**
      * This is a workaround for a bug where webkit forgets to relayout
      * the text when a new character is inserted at the beginning of a line in

--- a/webodf/lib/ops/OpMoveCursor.js
+++ b/webodf/lib/ops/OpMoveCursor.js
@@ -55,6 +55,8 @@ ops.OpMoveCursor = function OpMoveCursor() {
         selectionType = data.selectionType || ops.OdtCursor.RangeSelection;
     };
 
+    this.isEdit = false;
+
     this.execute = function (odtDocument) {
         var cursor = odtDocument.getCursor(memberid),
             selectedRange;

--- a/webodf/lib/ops/OpRemoveAnnotation.js
+++ b/webodf/lib/ops/OpRemoveAnnotation.js
@@ -57,6 +57,8 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
         domUtils = new core.DomUtils();
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         var iterator = odtDocument.getIteratorAtPosition(position),
             container = iterator.container(),

--- a/webodf/lib/ops/OpRemoveBlob.js
+++ b/webodf/lib/ops/OpRemoveBlob.js
@@ -53,6 +53,8 @@ ops.OpRemoveBlob = function OpRemoveBlob() {
         filename = data.filename;
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         odtDocument.getOdfCanvas().odfContainer().removeBlob(filename);
         return true;

--- a/webodf/lib/ops/OpRemoveCursor.js
+++ b/webodf/lib/ops/OpRemoveCursor.js
@@ -52,6 +52,8 @@ ops.OpRemoveCursor = function OpRemoveCursor() {
         timestamp = data.timestamp;
     };
 
+    this.isEdit = false;
+
     this.execute = function (odtDocument) {
         if (!odtDocument.removeCursor(memberid)) {
             return false;

--- a/webodf/lib/ops/OpRemoveMember.js
+++ b/webodf/lib/ops/OpRemoveMember.js
@@ -41,6 +41,8 @@ ops.OpRemoveMember = function OpRemoveMember() {
         timestamp = parseInt(data.timestamp, 10);
     };
 
+    this.isEdit = false;
+
     this.execute = function (odtDocument) {
         if (!odtDocument.getMember(memberid)) {
             return false;

--- a/webodf/lib/ops/OpRemoveStyle.js
+++ b/webodf/lib/ops/OpRemoveStyle.js
@@ -54,6 +54,8 @@ ops.OpRemoveStyle = function OpRemoveStyle() {
         styleFamily = data.styleFamily;
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         var styleNode = odtDocument.getStyleElement(styleName, styleFamily);
 

--- a/webodf/lib/ops/OpRemoveText.js
+++ b/webodf/lib/ops/OpRemoveText.js
@@ -86,6 +86,8 @@ ops.OpRemoveText = function OpRemoveText() {
         odfNodeNamespaceMap[odf.Namespaces.textns] = true;
     };
 
+    this.isEdit = true;
+
     /**
      * Defines a set of rules for how elements can be collapsed based on whether they contain ODT content (e.g.,
      * text or character elements).

--- a/webodf/lib/ops/OpSetBlob.js
+++ b/webodf/lib/ops/OpSetBlob.js
@@ -55,6 +55,8 @@ ops.OpSetBlob = function OpSetBlob() {
         content = data.content;
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         odtDocument.getOdfCanvas().odfContainer().setBlob(filename, mimetype, content);
         return true;

--- a/webodf/lib/ops/OpSetParagraphStyle.js
+++ b/webodf/lib/ops/OpSetParagraphStyle.js
@@ -55,6 +55,8 @@ ops.OpSetParagraphStyle = function OpSetParagraphStyle() {
         styleName = data.styleName;
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         var iterator, paragraphNode;
 

--- a/webodf/lib/ops/OpSplitParagraph.js
+++ b/webodf/lib/ops/OpSplitParagraph.js
@@ -55,6 +55,8 @@ ops.OpSplitParagraph = function OpSplitParagraph() {
         odfUtils = new odf.OdfUtils();
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         var domPosition, paragraphNode, targetNode,
             node, splitNode, splitChildNode, keptChildNode;

--- a/webodf/lib/ops/OpUpdateMember.js
+++ b/webodf/lib/ops/OpUpdateMember.js
@@ -52,6 +52,8 @@ ops.OpUpdateMember = function OpUpdateMember() {
         removedProperties = data.removedProperties;
     };
 
+    this.isEdit = false;
+
     function updateCreators() {
         var xpath = new xmldom.XPath(),
             xp = "//dc:creator[@editinfo:memberid='" + memberid + "']",

--- a/webodf/lib/ops/OpUpdateParagraphStyle.js
+++ b/webodf/lib/ops/OpUpdateParagraphStyle.js
@@ -78,6 +78,8 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
         removedProperties = data.removedProperties;
     };
 
+    this.isEdit = true;
+
     this.execute = function (odtDocument) {
         var formatting = odtDocument.getFormatting(),
             styleNode,

--- a/webodf/lib/ops/Operation.js
+++ b/webodf/lib/ops/Operation.js
@@ -54,6 +54,15 @@ ops.Operation = function Operation() {
 ops.Operation.prototype.init = function (data) {"use strict"; };
 
 /**
+ * This is meant to indicate whether
+ * the operation is an 'edit', i.e.
+ * causes any changes that would make
+ * it into the saved ODF.
+ * @type {!boolean}
+ */
+ops.Operation.prototype.isEdit;
+
+/**
  * @param {!ops.OdtDocument} odtDocument
  * @return {!boolean}
  */


### PR DESCRIPTION
To make life easier by avoiding the need to listen
to various signals or look at optypes when you just
want to know whether any edits have taken place.
