### PR TITLE
Remove unsupported metadata fields upon first edit

### DIFF
--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -82,7 +82,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         /**@const*/FILTER_REJECT = core.PositionFilter.FilterResult.FILTER_REJECT,
         filter,
         stepsTranslator,
-        lastEditingOp;
+        lastEditingOp,
+        unsupportedMetadataRemoved = false;
 
     /**
      * @return {!Element}
@@ -366,6 +367,15 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
             // then increment meta:editing-cycles by 1.
             if (!lastEditingOp) {
                 metadataManager.incrementEditingCycles();
+                // Remove certain metadata fields that
+                // should be updated as soon as edits happen,
+                // but cannot be because we don't support those yet.
+                if (!unsupportedMetadataRemoved) {
+                    metadataManager.setMetadata(null, [
+                        "meta:editing-duration",
+                        "meta:document-statistic"
+                    ]);
+                }
             }
 
             lastEditingOp = op;


### PR DESCRIPTION
We should remove `meta:document-statistic` and `meta:editing-duration` upon the first edit, because otherwise they'd be inconsistent with the rest of the document and with `dc:date` respectively.

These two are not being dealt with right now because:
- `meta:editing-duration` deals with ISO durations which are not trivially possible to reliably make without a good library (think 28 days in February, leap years, etc).
- `meta:document-statistic` is a different/new feature that requires some significant time investment.
