### PR TITLE
Fix post-annotation cursor positions

### DIFF
--- a/webodf/lib/ops/OpAddAnnotation.js
+++ b/webodf/lib/ops/OpAddAnnotation.js
@@ -65,7 +65,7 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
      * a list, inside it; and with the given annotation name
      * @param {!ops.OdtDocument} odtDocument
      * @param {!Date} date
-     * @return {!Node}
+     * @return {!Element}
      */
     function createAnnotationNode(odtDocument, date) {
         var annotationNode, creatorNode, dateNode,
@@ -100,7 +100,7 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
 
     /**
      * Creates an office:annotation-end node with the given annotation name
-     * @return {!Node}
+     * @return {!Element}
      */
     function createAnnotationEnd() {
         var annotationEnd;
@@ -113,9 +113,9 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
     }
 
     /**
-     * Inserts the node at a given position
+     * Inserts the element at a given position
      * @param {!ops.OdtDocument} odtDocument
-     * @param {!Node} node
+     * @param {!Element} node
      * @param {!number} insertPosition
      * @return {undefined}
      */


### PR DESCRIPTION
Instead of trying to guesstimate the ideal position of the cursor inside the newly created annotation, use `cursor.setSelectedRange` to move the cursor into the annotation's contained paragraph, taking advantage of the better positioning framework we have now.

Fixes #47 and #115.
