### PR TITLE
Extend step translation interface to allow custom rounding

### DIFF
--- a/programs/editor/EditorSession.js
+++ b/programs/editor/EditorSession.js
@@ -50,6 +50,7 @@ define("webodf/editor/EditorSession", [
     runtime.loadClass("core.DomUtils");
     runtime.loadClass("odf.OdfUtils");
     runtime.loadClass("ops.OdtDocument");
+    runtime.loadClass("ops.StepsTranslator");
     runtime.loadClass("ops.Session");
     runtime.loadClass("odf.Namespaces");
     runtime.loadClass("odf.OdfCanvas");
@@ -309,6 +310,15 @@ define("webodf/editor/EditorSession", [
         };
 
         /**
+         * Round the step up to the next step
+         * @param {!number} step
+         * @returns {!boolean}
+         */
+        function roundUp(step) {
+            return step === ops.StepsTranslator.NEXT_STEP;
+        }
+
+        /**
          * Applies the paragraph style with the given
          * style name to all the paragraphs within
          * the cursor selection.
@@ -321,7 +331,7 @@ define("webodf/editor/EditorSession", [
                 opQueue = [];
 
             paragraphs.forEach(function (paragraph) {
-                var paragraphStartPoint = odtDocument.convertDomPointToCursorStep(paragraph, 0, true),
+                var paragraphStartPoint = odtDocument.convertDomPointToCursorStep(paragraph, 0, roundUp),
                     paragraphStyleName = paragraph.getAttributeNS(odf.Namespaces.textns, "style-name"),
                     opSetParagraphStyle;
 

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -182,13 +182,13 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     /**
      * @param {!Node} node
      * @param {!number} offset
-     * @param {?boolean=} roundToNextPosition If the position is not accepted,
-     * round to the next closest allowed one if this argument is true. Otherwise,
-     * round to the previous closest allowed position.
+     * @param {function(!number, !Node, !number):!boolean=} roundDirection if the node & offset
+     * is not in an accepted location, this delegate is used to choose between rounding up or
+     * rounding down to the nearest step. If not provided, the default behaviour is to round down.
      * @returns {!number}
      */
-    this.convertDomPointToCursorStep = function (node, offset, roundToNextPosition) {
-        return stepsTranslator.convertDomPointToSteps(node, offset, roundToNextPosition);
+    this.convertDomPointToCursorStep = function (node, offset, roundDirection) {
+        return stepsTranslator.convertDomPointToSteps(node, offset, roundDirection);
     };
 
     /**


### PR DESCRIPTION
Step translation from a DOM point to a step usually results in some
rounding. The existing interface provided a simple bool flag to control
this, but this does not provide help for a caller that doesn't know
ahead of time which step is "closer" to the desired node (e.g., asking
for steps at paragraph boundaries should round within the paragraph).

This extension now allows a custom delegate that will be called with the
prev and next position to choose between rounding options.
