### PR TITLE
In the tests get <text:p> elements with getElementsByTagNameNS, not getElementsByTagName

### DIFF
--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -514,7 +514,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_BeginningOfTextNode() {
         var doc = createOdtDocument("<text:p>ABCD</text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(0);
 
@@ -526,7 +526,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_EndOfTextNode() {
         var doc = createOdtDocument("<text:p>ABCD</text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(4);
 
@@ -538,7 +538,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_PositionWithNoTextNode_AddsNewNode_Front() {
         var doc = createOdtDocument("<text:p><text:s> </text:s></text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(0);
 
@@ -550,7 +550,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_PositionWithNoTextNode_AddsNewNode_Back() {
         var doc = createOdtDocument("<text:p><text:s> </text:s></text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(1);
 
@@ -562,7 +562,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_At0_PutsTargetMemberCursor_AfterTextNode() {
         var doc = createOdtDocument("<text:p>ABCD</text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(0, inputMemberId);
 
@@ -575,7 +575,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_At1_PutsTargetMemberCursor_AfterTextNode() {
         var doc = createOdtDocument("<text:p>ABCD</text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
         setCursorPosition(1);
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(1, inputMemberId);
@@ -589,7 +589,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_At4_PutsTargetMemberCursor_AfterTextNode() {
         var doc = createOdtDocument("<text:p>ABCD</text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
         setCursorPosition(4);
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(4, inputMemberId);
@@ -603,7 +603,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_AfterNonText_PutsTargetMemberCursor_AfterTextNode() {
         var doc = createOdtDocument("<text:p>ABC<text:s> </text:s></text:p>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
         setCursorPosition(4);
 
         t.domPosition = t.odtDocument.getTextNodeAtStep(4, inputMemberId);
@@ -617,7 +617,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function getTextNodeAtStep_RearrangesExistingCursors_MovesMemberAfterTextNode() {
         var doc = createOdtDocument("<text:p/>");
-        t.paragraph = doc.getElementsByTagName("p")[0];
+        t.paragraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
         t.odtDocument.addCursor(new ops.OdtCursor("new 1", t.odtDocument));
         t.odtDocument.addCursor(new ops.OdtCursor("new 2", t.odtDocument));
 

--- a/webodf/tests/ops/StepsTranslatorTests.js
+++ b/webodf/tests/ops/StepsTranslatorTests.js
@@ -154,7 +154,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertStepsToDomPoint_At0() {
         var doc = createDoc("<text:p>AB</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.expected = {node: p.firstChild, offset: 0};
         t.position = t.translator.convertStepsToDomPoint(0);
@@ -165,7 +165,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertStepsToDomPoint_At1() {
         var doc = createDoc("<text:p>AB</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.expected = {node: p.firstChild, offset: 1};
         t.position = t.translator.convertStepsToDomPoint(1);
@@ -176,7 +176,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertStepsToDomPoint_At5() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>EF</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.expected = {node: p.firstChild, offset: 0};
         t.position = t.translator.convertStepsToDomPoint(5);
@@ -187,7 +187,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertStepsToDomPoint_LessThan0_Returns0() {
         var doc = createDoc("<text:p>AB</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.expected = {node: p.firstChild, offset: 0};
         t.position = t.translator.convertStepsToDomPoint(-1);
@@ -206,7 +206,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertStepsToDomPoint_Prime_PrimesCache() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>EF</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.translator.prime();
         t.filter.popCallCount();
@@ -260,7 +260,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertStepsToDomPoint_Cached_ContentAddedBeforeWalkablePosition() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>EF</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.expected = t.translator.convertStepsToDomPoint(5);
         t.uncachedCallCount = t.filter.popCallCount();
@@ -297,7 +297,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_At0() {
         var doc = createDoc("<text:p>AB</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.steps = t.translator.convertDomPointToSteps(p.firstChild, 0);
         r.shouldBe(t, "t.filter.acceptPositionCalls", "4");
@@ -306,7 +306,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_Before0() {
         var doc = createDoc("<text:p>AB</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.steps = t.translator.convertDomPointToSteps(p, 0);
         r.shouldBe(t, "t.filter.acceptPositionCalls", "4");
@@ -338,7 +338,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_At1() {
         var doc = createDoc("<text:p>AB</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.steps = t.translator.convertDomPointToSteps(p.firstChild, 1);
         r.shouldBe(t, "t.filter.acceptPositionCalls", "5");
@@ -347,7 +347,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_BetweenPositions_RoundsDown() {
         var doc = createDoc("<text:p>A<text:span/><text:span/>B</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.steps1 = t.translator.convertDomPointToSteps(p, 1);
         t.steps2 = t.translator.convertDomPointToSteps(p, 2);
@@ -357,7 +357,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_At5() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>EF</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.steps = t.translator.convertDomPointToSteps(p.firstChild, 0);
         r.shouldBe(t, "t.filter.acceptPositionCalls", "10");
@@ -366,7 +366,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_WithinParagraph_BeforeFirstWalkablePosition_RoundsDown() {
         var doc = createDoc("<text:p>AB</text:p><text:p><text:span/>C</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.steps = t.translator.convertDomPointToSteps(p, 0);
         r.shouldBe(t, "t.filter.acceptPositionCalls", "8");
@@ -384,7 +384,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_BetweenPositions_RoundingCheck() {
         var doc = createDoc("<text:p>A<text:span/><text:span/>B</text:p>"),
-            p = doc.getElementsByTagName("p")[0];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0];
 
         t.steps1 = t.translator.convertDomPointToSteps(p, 2, roundDown);
         t.steps2 = t.translator.convertDomPointToSteps(p, 2, roundUp);
@@ -394,7 +394,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_Cached_FirstPositionInParagraph_ConsistentWhenCached() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>C</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.steps = t.translator.convertDomPointToSteps(p, 0);
         t.stepsCached = t.translator.convertDomPointToSteps(p, 0);
@@ -404,7 +404,7 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function convertDomPointsToSteps_Cached_SpeedsUpSecondCall() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>EF</text:p>"),
-            p = doc.getElementsByTagName("p")[1];
+            p = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1];
 
         t.expected = t.translator.convertDomPointToSteps(p.firstChild, 0);
         t.uncachedCallCount = t.filter.popCallCount();
@@ -573,10 +573,10 @@ ops.StepsTranslatorTests = function StepsTranslatorTests(runner) {
 
     function handleStepsRemoved_AtDocumentStart() {
         var doc = createDoc("<text:p>ABCD</text:p><text:p>EFG</text:p>"),
-            removedParagraph = doc.getElementsByTagName("p")[0],
+            removedParagraph = doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[0],
             paragraphs = [];
 
-        paragraphs.push(createParagraphBoundary(doc.getElementsByTagName("p")[1]));
+        paragraphs.push(createParagraphBoundary(doc.getElementsByTagNameNS(odf.Namespaces.textns, "p")[1]));
         t.translator.prime();
         t.filter.popCallCount();
 


### PR DESCRIPTION
Seems Firefox just ignores namespaced elements in getElementsByTagName
