### PR TITLE
Initialise meta data manager when loading flat ODTs

### DIFF
--- a/webodf/lib/odf/OdfContainer.js
+++ b/webodf/lib/odf/OdfContainer.js
@@ -594,6 +594,8 @@ runtime.loadClass("odf.MetadataManager");
             root.masterStyles = getDirectChild(root, officens, 'master-styles');
             root.body = getDirectChild(root, officens, 'body');
             root.meta = getDirectChild(root, officens, 'meta');
+            runtime.assert(Boolean(root.meta), "Document has no top level meta element defined");
+            initializeMetadataManager(/**@type{!Element}*/(root.meta));
         }
         /**
          * @param {Document|undefined} xmldoc


### PR DESCRIPTION
Additionally, whenever the root element is updated, reinitialise the meta data manager with the new meta element.
