### PR TITLE
Clear more timeouts on call of destroy() methods

### DIFF
--- a/webodf/lib/gui/Caret.js
+++ b/webodf/lib/gui/Caret.js
@@ -395,6 +395,7 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
      * @return {undefined}
      */
     this.destroy = function (callback) {
+        runtime.clearTimeout(blinkTimeout);
         avatar.destroy(function (err) {
             if (err) {
                 callback(err);

--- a/webodf/lib/gui/CaretManager.js
+++ b/webodf/lib/gui/CaretManager.js
@@ -54,6 +54,7 @@ gui.CaretManager = function CaretManager(sessionController) {
     var /**@type{!Object.<string,!gui.Caret>}*/
         carets = {},
         window = runtime.getWindow(),
+        ensureCaretVisibleTimeoutId,
         scrollIntoViewScheduled = false;
 
     /**
@@ -124,7 +125,7 @@ gui.CaretManager = function CaretManager(sessionController) {
                 // Delay the actual scrolling just in case there are a batch of
                 // operations being performed. 50ms is close enough to "instant"
                 // that the user won't notice the delay here.
-                runtime.setTimeout(executeEnsureCaretVisible, 50);
+                ensureCaretVisibleTimeoutId = runtime.setTimeout(executeEnsureCaretVisible, 50);
             }
         }
     }
@@ -229,6 +230,7 @@ gui.CaretManager = function CaretManager(sessionController) {
             eventManager = sessionController.getEventManager(),
             caretArray = getCarets();
 
+        runtime.clearTimeout(ensureCaretVisibleTimeoutId);
         odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, ensureLocalCaretVisible);
         odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, refreshLocalCaretBlinking);
         odtDocument.unsubscribe(ops.OdtDocument.signalCursorRemoved, removeCaret);

--- a/webodf/lib/gui/EditInfoMarker.js
+++ b/webodf/lib/gui/EditInfoMarker.js
@@ -54,8 +54,9 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
         handle,
         marker,
         editinfons = 'urn:webodf:names:editinfo',
-        decay1,
-        decay2,
+        decayTimer0,
+        decayTimer1,
+        decayTimer2,
         decayTimeStep = 10000; // 10 seconds
 
     /**
@@ -73,10 +74,10 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
 
     /**
      * Stops the specified timer
-     * @param {number} timer
+     * @param {number} timerId
      */
-    function deleteDecay(timer) {
-        runtime.clearTimeout(timer);
+    function deleteDecay(timerId) {
+        runtime.clearTimeout(timerId);
     }
 
     function setLastAuthor(memberid) {
@@ -91,12 +92,8 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
         setLastAuthor(memberid);
 
         // Since a new edit has arrived, stop decaying for the old edits
-        if (decay1) {
-            deleteDecay(decay1);
-        }
-        if (decay2) {
-            deleteDecay(decay2);
-        }
+        deleteDecay(decayTimer1);
+        deleteDecay(decayTimer2);
 
         // Decide the decay path:
         // this decides the initial opacity and subsequent decays to apply
@@ -105,14 +102,14 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
         // an opaque marker in that case, we would want it to start with a lower opacity
         // and decay accordingly further, if possible.
         if (age < decayTimeStep) {
-            applyDecay(1, 0);
-            decay1 = applyDecay(0.5, decayTimeStep - age);
-            decay2 = applyDecay(0.2, decayTimeStep * 2 - age);
+            decayTimer0 = applyDecay(1, 0);
+            decayTimer1 = applyDecay(0.5, decayTimeStep - age);
+            decayTimer2 = applyDecay(0.2, decayTimeStep * 2 - age);
         } else if (age >= decayTimeStep && age < decayTimeStep * 2) {
-            applyDecay(0.5, 0);
-            decay2 = applyDecay(0.2, decayTimeStep * 2 - age);
+            decayTimer0 = applyDecay(0.5, 0);
+            decayTimer2 = applyDecay(0.2, decayTimeStep * 2 - age);
         } else {
-            applyDecay(0.2, 0);
+            decayTimer0 = applyDecay(0.2, 0);
         }
     };
     this.getEdits = function () {
@@ -159,6 +156,9 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
      * @return {undefined}
      */
     this.destroy = function(callback) {
+        deleteDecay(decayTimer0);
+        deleteDecay(decayTimer1);
+        deleteDecay(decayTimer2);
         editInfoNode.removeChild(marker);
         handle.destroy(function(err) {
             if (err) {

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -92,6 +92,7 @@ gui.SessionController = (function () {
             objectNameGenerator = new odf.ObjectNameGenerator(odtDocument.getOdfCanvas().odfContainer(), inputMemberId),
             isMouseMoved = false,
             mouseDownRootFilter = null,
+            handleMouseClickTimeoutId,
             undoManager = null,
             eventManager = new gui.EventManager(odtDocument),
             annotationController = new gui.AnnotationController(session, inputMemberId),
@@ -954,7 +955,7 @@ gui.SessionController = (function () {
                     // the click is processed. Set 0 timeout here so the newly clicked position can be updated
                     // by the browser. Unfortunately this is only working in Firefox. For other browsers, we have to work
                     // out the caret position from two coordinates.
-                    runtime.setTimeout(function() {
+                    handleMouseClickTimeoutId = runtime.setTimeout(function() {
                         var selection = mutableSelection(window.getSelection()),
                             selectionRange,
                             caretPos;
@@ -1185,6 +1186,7 @@ gui.SessionController = (function () {
          */
         this.destroy = function(callback) {
             var destroyCallbacks = [drawShadowCursorTask.destroy, directTextStyler.destroy];
+            runtime.clearTimeout(handleMouseClickTimeoutId);
             if (directParagraphStyler) {
                 destroyCallbacks.push(directParagraphStyler.destroy);
             }

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1028,6 +1028,7 @@ runtime.loadClass("gui.AnnotationViewManager");
             zoomLevel = 1,
             /**@type{!Object.<string,!Array.<!Function>>}*/
             eventHandlers = {},
+            waitingForDoneTimeoutId,
             loadingQueue = new LoadingQueue();
 
         /**
@@ -1298,12 +1299,12 @@ runtime.loadClass("gui.AnnotationViewManager");
                 // FIXME: use callback registry instead of replacing the onchange
                 runtime.log("WARNING: refreshOdf called but ODF was not DONE.");
 
-                runtime.setTimeout(function later_cb() {
+                waitingForDoneTimeoutId = runtime.setTimeout(function later_cb() {
                     if (odfcontainer.state === odf.OdfContainer.DONE) {
                         callback();
                     } else {
                         runtime.log("will be back later...");
-                        runtime.setTimeout(later_cb, 500);
+                        waitingForDoneTimeoutId = runtime.setTimeout(later_cb, 500);
                     }
                 }, 100);
             }
@@ -1589,6 +1590,7 @@ runtime.loadClass("gui.AnnotationViewManager");
          */
         this.destroy = function(callback) {
             var head = /**@type{!HTMLHeadElement}*/(doc.getElementsByTagName('head')[0]);
+            runtime.clearTimeout(waitingForDoneTimeoutId);
             // TODO: anything to clean with annotationViewManager?
             if (annotationsPane && annotationsPane.parentNode) {
                 annotationsPane.parentNode.removeChild(annotationsPane);


### PR DESCRIPTION
Cares for all timeouts I found critical (or at least where IMHO safe is better than sorry), solves issue #107
