### PR TITLE
Unbreak loading of ODP files

### DIFF
--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -252,17 +252,18 @@ runtime.loadClass("gui.AnnotationViewManager");
         }
 
         var masterStyles = odfContainer.rootElement.masterStyles,
-            masterPageElement = masterStyles.firstElementChild;
+            masterStylesChild = masterStyles.firstElementChild;
 
-        while (masterPageElement) {
-            if (masterPageElement.getAttributeNS(stylens, 'name')
+        while (masterStylesChild) {
+            if (masterStylesChild.getAttributeNS(stylens, 'name')
                     === masterPageName
-                    && masterPageElement.localName === "master-page"
-                    && masterPageElement.namespaceURI === stylens) {
+                    && masterStylesChild.localName === "master-page"
+                    && masterStylesChild.namespaceURI === stylens) {
                 break;
             }
+            masterStylesChild = masterStylesChild.nextElementSibling;
         }
-        return masterPageElement;
+        return masterStylesChild;
     }
 
     /**


### PR DESCRIPTION
Fix infinite loop that tries to acquire a master page element (to lay behind a `<draw:page>`) when given a master page name, which crept in by mistake via 9984265c.

One more reason why we can never have too many tests... :D
