### PR TITLE
Correct selection over bleed when selecting from the first step inside an annotation

### DIFF
--- a/webodf/lib/odf/OdfUtils.js
+++ b/webodf/lib/odf/OdfUtils.js
@@ -809,8 +809,8 @@ odf.OdfUtils = function OdfUtils() {
          */
         function nodeFilter(node) {
             nodeRange.selectNodeContents(node);
-            // do not return anything inside the character element
-            if (isCharacterElement(node.parentNode)) {
+            // do not return anything inside an character element or an inline root such as an annotation
+            if (isCharacterElement(node.parentNode) || isInlineRoot(node.parentNode)) {
                 return NodeFilter.FILTER_REJECT;
             }
 

--- a/webodf/tests/odf/OdfUtilsTests.js
+++ b/webodf/tests/odf/OdfUtilsTests.js
@@ -242,6 +242,31 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
         r.shouldBe(t, "t.imageElements.shift()", "t.doc.childNodes[0].firstChild.firstChild.firstChild");
         r.shouldBe(t, "t.imageElements.shift()", "t.doc.childNodes[1].firstChild.firstChild.firstChild.firstChild");
     }
+    function getTextElements_InlineRoots_ExcludesSubRoots() {
+        t.doc = createDocument("<text:p>abc<div xmlns='http://www.w3.org/1999/xhtml' class='annotationWrapper'><office:annotation>def</office:annotation></div>ghi</text:p>");
+        t.range.selectNode(t.doc);
+
+        t.textElements = t.odfUtils.getTextElements(t.range, false, false);
+
+        r.shouldBe(t, "t.textElements.length", "3");
+        r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[0]");
+        r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[1]");
+        r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[2]");
+    }
+    function getTextElements_ContainedWithinRoot_StaysBounded() {
+        t.doc = createDocument("<text:p>abc<div xmlns='http://www.w3.org/1999/xhtml' class='annotationWrapper'>" +
+            "<office:annotation>" +
+            "<text:list><text:list-item><text:p>def</text:p></text:list-item></text:list>" +
+            "</office:annotation>" +
+            "</div>ghi</text:p>");
+        t.annotationText = t.doc.childNodes[1].firstChild.firstChild.firstChild.firstChild.firstChild; // should be "def"
+        t.range.selectNodeContents(t.annotationText.parentNode);
+
+        t.textElements = t.odfUtils.getTextElements(t.range, true, false);
+
+        r.shouldBe(t, "t.textElements.length", "1");
+        r.shouldBe(t, "t.textElements.shift()", "t.annotationText");
+    }
     function isDowngradableWhitespace_DowngradesFirstSpaceAfterChar() {
         t.doc = createDocument("<text:p>a<text:s> </text:s>b</text:p>");
         t.isDowngradable = t.odfUtils.isDowngradableSpaceElement(t.doc.childNodes[1]);
@@ -292,6 +317,8 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
             getTextElements_ExcludesInsignificantWhitespace,
             getTextElements_CharacterElements,
             getImageElements_ReturnTwoImages,
+            getTextElements_InlineRoots_ExcludesSubRoots,
+            getTextElements_ContainedWithinRoot_StaysBounded,
 
             isDowngradableWhitespace_DowngradesFirstSpaceAfterChar,
             isDowngradableWhitespace_DowngradesFirstSpaceAfterTab,


### PR DESCRIPTION
Recent redefinitions of OdfUtils.isCharacterElement introduced an issue that caused the selection view to draw the client rect for the annotation wrapper.

Problem was introduced in 6c7b902.

Reproduction steps
1) Open http://ci.kogmbh.com/deploy/WebODF/webodf-ci-b119-g81f5e569/editor/localeditor.html
2) Click at the first cursor position in the first annotation (i.e., Just to the left of the "And it can do...")
3) Press shift+down arrow to extend the selection down a line
4) Observe that a big grey rectangle appears covering the whole distance of the line indicating the annotation anchor

![screen shot 2013-12-10 at 3 06 06 pm](https://f.cloud.github.com/assets/1052079/1711500/74919b04-6150-11e3-8fdd-bf6f2a79f183.png)
