### PR TITLE
Fix bug where ODP page numbers would be hidden.

### DIFF
--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -277,7 +277,7 @@ runtime.loadClass("gui.AnnotationViewManager");
         for (i = 0; i < clonedDrawFrameElements.length; i += 1) {
             element = /**@type{!Element}*/(clonedDrawFrameElements[i]);
             presentationClass = element.getAttributeNS(presentationns, 'class');
-            if (presentationClass && ! /^(date-time|footer|header|page-number')$/.test(presentationClass)) {
+            if (presentationClass && ! /^(date-time|footer|header|page-number)$/.test(presentationClass)) {
                 element.parentNode.removeChild(element);
             }
         }


### PR DESCRIPTION
In a9c4f35245d058982a4366d826c42afb41d12ba6, the regex for checking whether the attribute `presentation:class` matches an approved set of values had an extra `'` at the end, which meant that frames with class `'page-number'` were being dropped. This is now fixed.

Fixes #125.
