### PR TITLE
Small improvements for tests

### DIFF
--- a/webodf/lib/core/UnitTester.js
+++ b/webodf/lib/core/UnitTester.js
@@ -153,8 +153,8 @@ core.UnitTestRunner = function UnitTestRunner() {
         runtime.log("pass", msg);
     }
     /**
-     * @param {!Array.<*>} a
-     * @param {!Array.<*>} b
+     * @param {!Array.<*>} a actual
+     * @param {!Array.<*>} b expected
      * @return {!boolean}
      */
     function areArraysEqual(a, b) {
@@ -178,8 +178,8 @@ core.UnitTestRunner = function UnitTestRunner() {
         return true;
     }
     /**
-     * @param {!Element} a
-     * @param {!Element} b
+     * @param {!Element} a actual
+     * @param {!Element} b expected
      * @param {!boolean} skipReverseCheck
      * @return {!boolean}
      */
@@ -206,8 +206,8 @@ core.UnitTestRunner = function UnitTestRunner() {
         return skipReverseCheck ? true : areAttributesEqual(b, a, true);
     }
     /**
-     * @param {!Node} a
-     * @param {!Node} b
+     * @param {!Node} a actual
+     * @param {!Node} b expected
      * @return {!boolean}
      */
     function areNodesEqual(a, b) {
@@ -284,11 +284,11 @@ core.UnitTestRunner = function UnitTestRunner() {
         if (typeof expected === "object" && typeof actual === "object") {
             if (/**@type{!Object}*/(expected).constructor === Element
                     || /**@type{!Object}*/(expected).constructor === Node) {
-                return areNodesEqual(/**@type{!Node}*/(expected),
-                                     /**@type{!Node}*/(actual));
+                return areNodesEqual(/**@type{!Node}*/(actual),
+                                     /**@type{!Node}*/(expected));
             }
-            return areObjectsEqual(/**@type{!Object}*/(expected),
-                                   /**@type{!Object}*/(actual));
+            return areObjectsEqual(/**@type{!Object}*/(actual),
+                                   /**@type{!Object}*/(expected));
         }
         return false;
     }

--- a/webodf/tests/ops/OperationTests.js
+++ b/webodf/tests/ops/OperationTests.js
@@ -277,7 +277,7 @@ ops.OperationTests = function OperationTests(runner) {
             sortChildrenByNSAttribute(stylesafter, odf.Namespaces.stylens, "name");
             styles.normalize();
             sortChildrenByNSAttribute(styles, odf.Namespaces.stylens, "name");
-            if (!r.areNodesEqual(stylesafter, styles)) {
+            if (!r.areNodesEqual(styles, stylesafter)) {
                 t.styles = serialize(styles);
                 t.stylesafter = serialize(stylesafter);
             } else {
@@ -291,7 +291,7 @@ ops.OperationTests = function OperationTests(runner) {
             sortChildrenByNSAttribute(autostylesafter, odf.Namespaces.stylens, "name");
             autostyles.normalize();
             sortChildrenByNSAttribute(autostyles, odf.Namespaces.stylens, "name");
-            if (!r.areNodesEqual(autostylesafter, autostyles)) {
+            if (!r.areNodesEqual(autostyles, autostylesafter)) {
                 t.autostyles = serialize(autostyles);
                 t.autostylesafter = serialize(autostylesafter);
             } else {
@@ -307,7 +307,7 @@ ops.OperationTests = function OperationTests(runner) {
             sortChildrenByTagName(metaafter);
             meta.normalize();
             sortChildrenByTagName(meta);
-            if (!r.areNodesEqual(metaafter, meta)) {
+            if (!r.areNodesEqual(meta, metaafter)) {
                 t.meta = serialize(meta);
                 t.metaafter = serialize(metaafter);
             } else {
@@ -318,7 +318,7 @@ ops.OperationTests = function OperationTests(runner) {
 
         textafter.normalize();
         text.normalize();
-        if (!r.areNodesEqual(textafter, text)) {
+        if (!r.areNodesEqual(text, textafter)) {
             t.text = serialize(text);
             t.after = serialize(textafter);
         } else {

--- a/webodf/tests/ops/TransformationTests.js
+++ b/webodf/tests/ops/TransformationTests.js
@@ -425,7 +425,7 @@ ops.TransformationTests = function TransformationTests(runner) {
             sortChildrenByNSAttribute(stylesafter, odf.Namespaces.stylens, "name");
             styles.normalize();
             sortChildrenByNSAttribute(styles, odf.Namespaces.stylens, "name");
-            if (!r.areNodesEqual(stylesafter, styles)) {
+            if (!r.areNodesEqual(styles, stylesafter)) {
                 t.styles = serialize(styles);
                 t.stylesafter = serialize(stylesafter);
             } else {
@@ -441,7 +441,7 @@ ops.TransformationTests = function TransformationTests(runner) {
             sortChildrenByTagName(/**@type{!Element}*/(metaafter));
             meta.normalize();
             sortChildrenByTagName(meta);
-            if (!r.areNodesEqual(metaafter, meta)) {
+            if (!r.areNodesEqual(meta, metaafter)) {
                 t.meta = serialize(meta);
                 t.metaafter = serialize(metaafter);
             } else {
@@ -454,7 +454,7 @@ ops.TransformationTests = function TransformationTests(runner) {
         normalizeCursorsAndAnchors(textafter);
         text.normalize();
         normalizeCursorsAndAnchors(text);
-        if (!r.areNodesEqual(textafter, text)) {
+        if (!r.areNodesEqual(text, textafter)) {
             t.text = serialize(text);
             t.after = serialize(textafter);
         } else {


### PR DESCRIPTION
I got confused by the currently actually reversed values in some of the "x should by y" log output. Time to change that, so here two small cleanup commits.

Not sure if the duplicated copyChildNodes should be moved into core.UnitTestRunner. In any case the general util classes seem wrong to me, as test-only code should not bloat the API of the normal code.
