### PR TITLE
Removed all references to node.parentElement

### DIFF
--- a/webodf/lib/gui/AnnotationViewManager.js
+++ b/webodf/lib/gui/AnnotationViewManager.js
@@ -203,10 +203,10 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
      * @return {undefined}
      */
     function renderAnnotation(annotation) {
-        var annotationNote = annotation.node.parentElement,
+        var annotationNote = /**@type{!Element}*/(annotation.node.parentNode),
             connectorHorizontal = annotationNote.nextElementSibling,
             connectorAngular = connectorHorizontal.nextElementSibling,
-            annotationWrapper = annotationNote.parentElement,
+            annotationWrapper = /**@type{!Element}*/(annotationNote.parentNode),
             connectorAngle = 0,
             previousAnnotation = annotations[annotations.indexOf(annotation) - 1],
             previousRect,
@@ -222,7 +222,7 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
                                           - CONNECTOR_MARGIN + 'px';
 
         if (previousAnnotation) {
-            previousRect = previousAnnotation.node.parentElement.getBoundingClientRect();
+            previousRect = /**@type{!Element}*/(previousAnnotation.node.parentNode).getBoundingClientRect();
             if ((annotationWrapper.getBoundingClientRect().top - previousRect.bottom) / zoomLevel <= NOTE_MARGIN) {
                 annotationNote.style.top = Math.abs(annotationWrapper.getBoundingClientRect().top - previousRect.bottom) / zoomLevel + NOTE_MARGIN + 'px';
             } else {

--- a/webodf/lib/odf/Formatting.js
+++ b/webodf/lib/odf/Formatting.js
@@ -412,7 +412,7 @@ odf.Formatting = function Formatting() {
             if (nodeStyles) {
                 appliedStyles.push(nodeStyles);
             }
-            parent = parent.parentElement;
+            parent = /**@type{!Element}*/(parent.parentNode);
         }
 
         /**

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -639,7 +639,7 @@ runtime.loadClass("gui.AnnotationViewManager");
                 node = node.firstElementChild;
             } else {
                 while (node && node !== odfbody && !node.nextElementSibling) {
-                    node = node.parentElement;
+                    node = /**@type{!Element}*/(node.parentNode);
                 }
                 if (node && node.nextElementSibling) {
                     node = node.nextElementSibling;

--- a/webodf/lib/odf/Style2CSS.js
+++ b/webodf/lib/odf/Style2CSS.js
@@ -594,7 +594,7 @@ odf.Style2CSS = function Style2CSS() {
             rule += 'font-family: ' + (value || fontName) + ';';
         }
 
-        parentStyle = props.parentElement;
+        parentStyle = /**@type{!Element}*/(props.parentNode);
         fontSize = getFontSize(parentStyle);
         // This is actually the font size of the current style.
         if (!fontSize) {
@@ -994,7 +994,7 @@ odf.Style2CSS = function Style2CSS() {
         }
 
         if (documentType === 'presentation') {
-            masterStyles = getDirectChild(node.parentNode.parentElement, officens, 'master-styles');
+            masterStyles = getDirectChild(/**@type{!Element}*/(node.parentNode.parentNode), officens, 'master-styles');
             e = masterStyles && masterStyles.firstElementChild;
             while (e) {
                 // Generate CSS for all the pages that use the master page that use this page-layout


### PR DESCRIPTION
Internet Explorer 11 does not support this property on HTML nodes.
