### PR TITLE
Add flag "showRemoveButton" to AnnotationViewManager, to not show the button if wanted

### DIFF
--- a/programs/editor/Editor.js
+++ b/programs/editor/Editor.js
@@ -482,7 +482,7 @@ define("webodf/editor/Editor", [
                     });
 
                 odfCanvas = new odf.OdfCanvas(canvasElement);
-                odfCanvas.enableAnnotations(annotationsEnabled);
+                odfCanvas.enableAnnotations(annotationsEnabled, true);
 
                 odfCanvas.addListener("statereadychange", function () {
                     var viewOptions = {

--- a/programs/viewer/ODFViewerPlugin.js
+++ b/programs/viewer/ODFViewerPlugin.js
@@ -95,7 +95,7 @@ function ODFViewerPlugin() {
                 initialized = true;
                 documentType = odfCanvas.odfContainer().getDocumentType(root);
                 if (documentType === 'text') {
-                    odfCanvas.enableAnnotations(true);
+                    odfCanvas.enableAnnotations(true, false);
                 }
                 self.onLoad();
             });

--- a/webodf/lib/gui/AnnotationViewManager.js
+++ b/webodf/lib/gui/AnnotationViewManager.js
@@ -68,8 +68,9 @@ gui.AnnotatableCanvas.prototype.getSizer = function () {"use strict"; };
  * @param {!gui.AnnotatableCanvas} canvas
  * @param {!Element} odfFragment
  * @param {!Element} annotationsPane
+ * @param {!boolean} showAnnotationRemoveButton
  */
-gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, annotationsPane) {
+gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, annotationsPane, showAnnotationRemoveButton) {
     "use strict";
     var /**@type{!Array.<!{node:!Element,end:Node}>}*/
         annotations = [],
@@ -93,7 +94,7 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
             annotationNote = doc.createElement('div'),
             connectorHorizontal = doc.createElement('div'),
             connectorAngular = doc.createElement('div'),
-            removeButton = doc.createElement('div'),
+            removeButton,
             annotationNode = annotation.node;
 
         annotationWrapper.className = 'annotationWrapper';
@@ -101,8 +102,11 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
 
         annotationNote.className = 'annotationNote';
         annotationNote.appendChild(annotationNode);
-        removeButton.className = 'annotationRemoveButton';
-        annotationNote.appendChild(removeButton);
+        if (showAnnotationRemoveButton) {
+            removeButton = doc.createElement('div');
+            removeButton.className = 'annotationRemoveButton';
+            annotationNote.appendChild(removeButton);
+        }
 
         connectorHorizontal.className = 'annotationConnector horizontal';
         connectorAngular.className = 'annotationConnector angular';

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1017,6 +1017,7 @@ runtime.loadClass("gui.AnnotationViewManager");
             /**@type{HTMLDivElement}*/
             annotationsPane = null,
             allowAnnotations = false,
+            showAnnotationRemoveButton = false,
             /**@type{gui.AnnotationViewManager}*/
             annotationViewManager = null,
             webodfcss,
@@ -1254,7 +1255,7 @@ runtime.loadClass("gui.AnnotationViewManager");
                 if (annotationViewManager) {
                     annotationViewManager.forgetAnnotations();
                 }
-                annotationViewManager = new gui.AnnotationViewManager(self, odfnode.body, annotationsPane);
+                annotationViewManager = new gui.AnnotationViewManager(self, odfnode.body, annotationsPane, showAnnotationRemoveButton);
                 modifyAnnotations(odfnode.body);
             } else {
                 if (annotationsPane.parentNode) {
@@ -1435,11 +1436,13 @@ runtime.loadClass("gui.AnnotationViewManager");
 
         /** Allows / disallows annotations
          * @param {!boolean} allow
+         * @param {!boolean} showRemoveButton
          * @return {undefined}
          */
-        this.enableAnnotations = function (allow) {
+        this.enableAnnotations = function (allow, showRemoveButton) {
             if (allow !== allowAnnotations) {
                 allowAnnotations = allow;
+                showAnnotationRemoveButton = showRemoveButton;
                 if (odfcontainer) {
                     handleAnnotations(odfcontainer.rootElement);
                 }


### PR DESCRIPTION
Fixes #247

A later iteration might want to allow enabling/disabling the button independent of allowing/disallowing the general annotation display, but this here should work for now.
