### PR TITLE
Switch to SVG polygons for drawing a SelectionView.

### DIFF
--- a/webodf/lib/gui/SessionView.js
+++ b/webodf/lib/gui/SessionView.js
@@ -164,7 +164,7 @@ gui.SessionView = (function () {
             setStyle('span.editInfoColor', '{ background-color: ' + color + '; }', '');
             setStyle('span.editInfoAuthor', '{ content: "' + name + '"; }', ':before');
             setStyle('dc|creator', '{ background-color: ' + color + '; }', '');
-            setStyle('div.selectionOverlay', '{ background-color: ' + color + ';}', '');
+            setStyle('.selectionOverlay', '{ fill: ' + color + '; stroke: ' + color + ';}', '');
         }
 
         /**

--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -11,6 +11,7 @@
 @namespace editinfo url(urn:webodf:names:editinfo);
 @namespace annotation url(urn:webodf:names:annotation);
 @namespace dc url(http://purl.org/dc/elements/1.1/);
+@namespace svgns url(http://www.w3.org/2000/svg);
 
 office|document > *, office|document-content > * {
   display: none;
@@ -482,13 +483,20 @@ dc|*::-moz-selection {
 
 .selectionOverlay {
     position: absolute;
-    z-index: 15;
-    opacity: 0.2;
     pointer-events: none;
     top: 0;
     left: 0;
-    width: 0;
-    height: 0;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 15;
+}
+.selectionOverlay > polygon {
+    fill-opacity: 0.3;
+    stroke-opacity: 0.8;
+    stroke-width: 1;
+    fill-rule: evenodd;
 }
 
 #imageSelector {


### PR DESCRIPTION
Adds an SVG overlay that takes no pointer-events, and uses a polygon element inside to it draw selections with the stroke and fill of the user's color. Removes the 3 divs used previously.

The stroke is more opaque than the fill.
