### PR TITLE
Fix broken passing of log messages to result of core.UnitTestLogger.endTest()

### DIFF
--- a/webodf/lib/core/UnitTester.js
+++ b/webodf/lib/core/UnitTester.js
@@ -154,9 +154,7 @@ core.UnitTestLogger = function UnitTestLogger() {
             description: test,
             suite: [suite, test],
             success: errors === 0,
-            log: messages.map(function (i) {
-                return i.message;
-            }),
+            log: messages,
             time: end - start
         };
     };


### PR DESCRIPTION
Fixup to 1b0bc3cf72d670a046cea55a53d875b12a0a7ac0

Closurecompiler could have catched that from the @return definition, possibly too complex.

Compare usage in core.UnitTester.reporter():
                m = r.log[i];
                runtime.log(m.category, m.message);
