### PR TITLE
Don't crash if edit-mode is entered twice

### DIFF
--- a/webodf/lib/gui/KeyboardHandler.js
+++ b/webodf/lib/gui/KeyboardHandler.js
@@ -87,10 +87,11 @@ gui.KeyboardHandler = function KeyboardHandler() {
      * @param {!number}     keyCode
      * @param {!number}     modifiers
      * @param {!Function}   callback
+     * @param {boolean=}   overwrite    Set to true to force a binding to be overwritten
      */
-    this.bind = function (keyCode, modifiers, callback) {
+    this.bind = function (keyCode, modifiers, callback, overwrite) {
         var keyCombo = getKeyCombo(keyCode, modifiers);
-        runtime.assert(bindings.hasOwnProperty(keyCombo) === false,
+        runtime.assert(overwrite || bindings.hasOwnProperty(keyCombo) === false,
             "tried to overwrite the callback handler of key combo: " + keyCombo);
         bindings[keyCombo] = callback;
     };

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -611,7 +611,7 @@ gui.SessionController = (function () {
             hyperlinkClickHandler.setEditing(true);
             // Most browsers will go back one page when given an unhandled backspace press
             // To prevent this, the event handler for this key should always return true
-            keyDownHandler.bind(keyCode.Backspace, modifier.None, returnTrue(textManipulator.removeTextByBackspaceKey));
+            keyDownHandler.bind(keyCode.Backspace, modifier.None, returnTrue(textManipulator.removeTextByBackspaceKey), true);
             keyDownHandler.bind(keyCode.Delete, modifier.None, textManipulator.removeTextByDeleteKey);
 
             // TODO: deselect the currently selected image when press Esc
@@ -681,8 +681,7 @@ gui.SessionController = (function () {
             eventManager.unsubscribe("beforepaste", handleBeforePaste);
 
             hyperlinkClickHandler.setEditing(false);
-            keyDownHandler.unbind(keyCode.Backspace, modifier.None);
-            keyDownHandler.bind(keyCode.Backspace, modifier.None, function () { return true; });
+            keyDownHandler.bind(keyCode.Backspace, modifier.None, function () { return true; }, true);
             keyDownHandler.unbind(keyCode.Delete, modifier.None);
             keyDownHandler.unbind(keyCode.Tab, modifier.None);
 


### PR DESCRIPTION
Entering, exiting, then re-entering edit mode would fail an assert due to overriding an existing key-binding. The keybindings handler now has a flag to ignore overriding errors, which makes life a little easier in this case as there is no need to unbind then rebind as was happening previously.
