### PR TITLE
Restore focus to the event trap if reset by an operation

### DIFF
--- a/webodf/lib/gui/DirectTextStyler.js
+++ b/webodf/lib/gui/DirectTextStyler.js
@@ -454,7 +454,7 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
         odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
         odtDocument.unsubscribe(ops.OdtDocument.signalParagraphStyleModified, onParagraphStyleModified);
         odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
-        odtDocument.unsubscribe(ops.OdtDocument.signalOperationExecuted, clearCursorStyle);
+        odtDocument.unsubscribe(ops.OdtDocument.signalOperationEnd, clearCursorStyle);
         callback();
     };
 
@@ -464,7 +464,7 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
         odtDocument.subscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
         odtDocument.subscribe(ops.OdtDocument.signalParagraphStyleModified, onParagraphStyleModified);
         odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
-        odtDocument.subscribe(ops.OdtDocument.signalOperationExecuted, clearCursorStyle);
+        odtDocument.subscribe(ops.OdtDocument.signalOperationEnd, clearCursorStyle);
         updatedCachedValues();
     }
 

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -75,7 +75,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
             ops.OdtDocument.signalCommonStyleCreated,
             ops.OdtDocument.signalCommonStyleDeleted,
             ops.OdtDocument.signalTableAdded,
-            ops.OdtDocument.signalOperationExecuted,
+            ops.OdtDocument.signalOperationStart,
+            ops.OdtDocument.signalOperationEnd,
             ops.OdtDocument.signalUndoStackChanged,
             ops.OdtDocument.signalStepsInserted,
             ops.OdtDocument.signalStepsRemoved
@@ -843,7 +844,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         stepsTranslator = new ops.StepsTranslator(getRootNode, gui.SelectionMover.createPositionIterator, filter, 500);
         eventNotifier.subscribe(ops.OdtDocument.signalStepsInserted, stepsTranslator.handleStepsInserted);
         eventNotifier.subscribe(ops.OdtDocument.signalStepsRemoved, stepsTranslator.handleStepsRemoved);
-        eventNotifier.subscribe(ops.OdtDocument.signalOperationExecuted, handleOperationExecuted);
+        eventNotifier.subscribe(ops.OdtDocument.signalOperationEnd, handleOperationExecuted);
     }
     init();
 };
@@ -859,7 +860,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
 /**@const*/ops.OdtDocument.signalCommonStyleCreated = "style/created";
 /**@const*/ops.OdtDocument.signalCommonStyleDeleted = "style/deleted";
 /**@const*/ops.OdtDocument.signalParagraphStyleModified = "paragraphstyle/modified";
-/**@const*/ops.OdtDocument.signalOperationExecuted = "operation/executed";
+/**@const*/ops.OdtDocument.signalOperationStart = "operation/start";
+/**@const*/ops.OdtDocument.signalOperationEnd = "operation/end";
 /**@const*/ops.OdtDocument.signalUndoStackChanged = "undo/changed";
 /**@const*/ops.OdtDocument.signalStepsInserted = "steps/inserted";
 /**@const*/ops.OdtDocument.signalStepsRemoved = "steps/removed";

--- a/webodf/lib/ops/Session.js
+++ b/webodf/lib/ops/Session.js
@@ -74,8 +74,9 @@ ops.Session = function Session(odfCanvas) {
     this.setOperationRouter = function (opRouter) {
         operationRouter = opRouter;
         opRouter.setPlaybackFunction(function (op) {
+            odtDocument.emit(ops.OdtDocument.signalOperationStart, op);
             if (op.execute(odtDocument)) {
-                odtDocument.emit(ops.OdtDocument.signalOperationExecuted, op);
+                odtDocument.emit(ops.OdtDocument.signalOperationEnd, op);
                 return true;
             }
             return false;

--- a/webodf/tests/ops/OperationTests.js
+++ b/webodf/tests/ops/OperationTests.js
@@ -263,7 +263,7 @@ ops.OperationTests = function OperationTests(runner) {
             op = factory.create(test.ops[i]);
             op.execute(t.odtDocument);
             if (metabefore) {
-                t.odtDocument.emit(ops.OdtDocument.signalOperationExecuted, op);
+                t.odtDocument.emit(ops.OdtDocument.signalOperationEnd, op);
             }
         }
 


### PR DESCRIPTION
With the event trap now being inside the cursor, any repositioning of the cursor causes the document.activeElement and window selection to change. This causes the document to stop being editable after actions such as bolding current text.

Now, the focus state of the event trap is checked prior to each operation, and will be reset back to the event trap if disrupted by an operation. Note, checks are in place to prevent stealing focus if the document is not active when an operation is executed.

Fixes issue #298
