### PR TITLE
Exclude any text content inside a cursor node the document text body

### DIFF
--- a/webodf/lib/odf/OdfUtils.js
+++ b/webodf/lib/odf/OdfUtils.js
@@ -724,8 +724,9 @@ odf.OdfUtils = function OdfUtils() {
             }
             break;
         default:
-            // Skip webodf edit markers
+            // Skip webodf edit markers or cursor information
             switch (node.localName) {
+            case 'cursor':
             case 'editinfo':
                 return false;
             }

--- a/webodf/tests/odf/OdfUtilsTests.js
+++ b/webodf/tests/odf/OdfUtilsTests.js
@@ -52,7 +52,8 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
             "draw":"urn:oasis:names:tc:opendocument:xmlns:drawing:1.0",
             "svg":"urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0",
             "dr3d":"urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0",
-            "xlink":"http://www.w3.org/1999/xlink"
+            "xlink":"http://www.w3.org/1999/xlink",
+            "cursor":"urn:webodf:names:cursor"
         };
 
     this.setUp = function () {
@@ -254,6 +255,16 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
         r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[1]");
         r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[2]");
     }
+    function getTextElements_InlineRoots_ExcludesCursorContent() {
+        t.doc = createDocument("<text:p>abc<cursor:cursor>def</cursor:cursor>ghi</text:p>");
+        t.range.selectNode(t.doc);
+
+        t.textElements = t.odfUtils.getTextElements(t.range, false, false);
+
+        r.shouldBe(t, "t.textElements.length", "2");
+        r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[0]");
+        r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[2]");
+    }
     function getTextElements_ContainedWithinRoot_StaysBounded() {
         t.doc = createDocument("<text:p>abc<div xmlns='http://www.w3.org/1999/xhtml' class='annotationWrapper'>" +
             "<office:annotation>" +
@@ -346,6 +357,7 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
             getTextElements_CharacterElements,
             getImageElements_ReturnTwoImages,
             getTextElements_InlineRoots_ExcludesSubRoots,
+            getTextElements_InlineRoots_ExcludesCursorContent,
             getTextElements_ContainedWithinRoot_StaysBounded,
 
             isDowngradableWhitespace_DowngradesFirstSpaceAfterChar,

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -358,6 +358,13 @@
   </ops>
   <after><office:text><text:p/></office:text></after>
  </test>
+ <test name="RemoveText_SurroundingCursor">
+  <before><office:text><text:p>a<c:cursor>b</c:cursor>c</text:p></office:text></before>
+  <ops>
+   <op optype="RemoveText" position="0" length="2"/>
+  </ops>
+  <after><office:text><text:p><c:cursor>b</c:cursor></text:p></office:text></after>
+ </test>
  <test name="AddRemoveSpace">
   <before><office:text><text:p>ab</text:p></office:text></before>
   <ops>


### PR DESCRIPTION
A cursor cannot contain valid document text, and should never be returned in text node or text elements collections.

I'm not happy about putting this in OdfUtils directly, but can't think of a better design at the moment.
