### PR TITLE
Only make the event trap editable if the document is in edit mode

### DIFF
--- a/webodf/lib/gui/InputMethodEditor.js
+++ b/webodf/lib/gui/InputMethodEditor.js
@@ -128,7 +128,8 @@ runtime.loadClass("ops.OdtCursor");
                                                 gui.InputMethodEditor.signalCompositionEnd]),
             lastCompositionData,
             filters = [],
-            cleanup;
+            cleanup,
+            isEditable = false;
 
         /**
          * Subscribe to IME events
@@ -316,15 +317,24 @@ runtime.loadClass("ops.OdtCursor");
             // https://bugzilla.mozilla.org/show_bug.cgi?id=773137
             // https://bugzilla.mozilla.org/show_bug.cgi?id=787305
             eventManager.blur();
-            eventTrap.setAttribute("contenteditable", "false");
+            eventTrap.setAttribute("contenteditable", false);
         }
 
         /**
          * Allow the event trap to receive focus
          */
         function restoreFocus() {
-            eventTrap.setAttribute("contenteditable", "true");
+            eventTrap.setAttribute("contenteditable", isEditable);
         }
+
+        /**
+         * Sets to true when in edit mode; otherwise false
+         * @param {!boolean} editable
+         */
+        this.setEditing = function(editable) {
+            isEditable = editable;
+            eventTrap.setAttribute("contenteditable", isEditable);
+        };
 
         function init() {
             eventManager.subscribe('compositionstart', compositionStart);
@@ -338,7 +348,6 @@ runtime.loadClass("ops.OdtCursor");
             filters.push(new DetectSafariCompositionError(eventManager));
             cleanup = filters.map(function(filter) { return filter.destroy; });
 
-            eventTrap.setAttribute("contenteditable", "true");
             // Negative tab index still allows focus, but removes accessibility by keyboard
             eventTrap.setAttribute("tabindex", -1);
             processUpdates = new core.ScheduledTask(resetWindowSelection, 1);

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -624,6 +624,7 @@ gui.SessionController = (function () {
                 undoManager.initialize();
             }
 
+            inputMethodEditor.setEditing(true);
             hyperlinkClickHandler.setEditing(true);
             // Most browsers will go back one page when given an unhandled backspace press
             // To prevent this, the event handler for this key should always return true
@@ -690,6 +691,7 @@ gui.SessionController = (function () {
             eventManager.unsubscribe("paste", handlePaste);
             eventManager.unsubscribe("beforepaste", handleBeforePaste);
 
+            inputMethodEditor.setEditing(false);
             hyperlinkClickHandler.setEditing(false);
             keyDownHandler.bind(keyCode.Backspace, modifier.None, function () { return true; }, true);
             keyDownHandler.unbind(keyCode.Delete, modifier.None);


### PR DESCRIPTION
Various browser menus (cut, delete) should only enable if the document is currently in edit mode.
