### PR TITLE
Fix a performance regression when deleting large amounts of text

### DIFF
--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -126,6 +126,12 @@ gui.SessionController = (function () {
 
         function saveFocus() {
             hadFocus = eventManager.hasFocus();
+            if (hadFocus) {
+                // Performing operations while the event manager has focus causes the browser to
+                // spend a lot of effort maintaining the global window selection.
+                // Avoid this by discarding focus before any operation
+                eventManager.blur();
+            }
         }
 
         /**


### PR DESCRIPTION
Having the event manager in focus during deletion causes text removal to be approximately 3x slower.
