### PR TITLE
Preserve both cursor and anchor nodes when removing an annotation

### DIFF
--- a/webodf/lib/ops/OpRemoveAnnotation.js
+++ b/webodf/lib/ops/OpRemoveAnnotation.js
@@ -64,8 +64,7 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
             container = iterator.container(),
             annotationName,
             annotationNode,
-            annotationEnd,
-            cursors;
+            annotationEnd;
 
         while (!(container.namespaceURI === odf.Namespaces.officens
             && container.localName === 'annotation')) {
@@ -87,10 +86,12 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
         odtDocument.getOdfCanvas().forgetAnnotations();
 
         // Move all cursors - outside and before the annotation node
-        cursors = domUtils.getElementsByTagNameNS(annotationNode, 'urn:webodf:names:cursor', 'cursor');
-        while (cursors.length) {
-            annotationNode.parentNode.insertBefore(cursors.pop(), annotationNode);
-        }
+        domUtils.getElementsByTagNameNS(annotationNode, 'urn:webodf:names:cursor', 'cursor').forEach(function(cursor) {
+            annotationNode.parentNode.insertBefore(cursor, annotationNode);
+        });
+        domUtils.getElementsByTagNameNS(annotationNode, 'urn:webodf:names:cursor', 'anchor').forEach(function(anchor) {
+            annotationNode.parentNode.insertBefore(anchor, annotationNode);
+        });
 
         // Delete start and end
         annotationNode.parentNode.removeChild(annotationNode);

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -1319,6 +1319,47 @@
    <office:text><text:p>ABCD</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
   </after>
  </test>
+ <test name="RemoveAnnotation_preservesExpandedCursor">
+  <before>
+   <office:text><text:p>ABC<office:annotation office:name="alice_2"><dc:creator e:memberid="Alice"/><dc:date>2013-08-05T12:34:07.061Z</dc:date><text:list><text:list-item><text:p></text:p></text:list-item></text:list></office:annotation>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
+  </before>
+  <ops>
+   <op optype="AddCursor" memberid="Alice" position="0" />
+   <op optype="MoveCursor" memberid="Alice" position="4" length="1" />
+   <op optype="RemoveAnnotation" memberid="Alice" position="4" length="0" />
+  </ops>
+  <after>
+   <office:text><text:p>ABC<c:cursor c:memberId="Alice"/>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
+  </after>
+ </test>
+ <test name="RemoveAnnotation_preservesExpandedCursor_2">
+  <before>
+   <office:text><text:p>ABC<office:annotation office:name="alice_2"><dc:creator e:memberid="Alice"/><dc:date>2013-08-05T12:34:07.061Z</dc:date><text:list><text:list-item><text:p></text:p></text:list-item></text:list></office:annotation>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
+  </before>
+  <ops>
+   <op optype="AddCursor" memberid="Alice" position="0" />
+   <op optype="MoveCursor" memberid="Alice" position="2" length="3" />
+   <op optype="RemoveAnnotation" memberid="Alice" position="4" length="0" />
+  </ops>
+  <after>
+   <office:text><text:p>AB<c:anchor c:memberId="Alice"/>C<c:cursor c:memberId="Alice"/>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
+  </after>
+ </test>
+ <test name="RemoveAnnotation_preservesMultipleExpandedCursors">
+  <before>
+   <office:text><text:p>ABC<office:annotation office:name="alice_2"><dc:creator e:memberid="Alice"/><dc:date>2013-08-05T12:34:07.061Z</dc:date><text:list><text:list-item><text:p>X</text:p></text:list-item></text:list></office:annotation>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
+  </before>
+  <ops>
+   <op optype="AddCursor" memberid="Alice" position="0" />
+   <op optype="AddCursor" memberid="Bob" position="0" />
+   <op optype="MoveCursor" memberid="Alice" position="4" length="1" />
+   <op optype="MoveCursor" memberid="Bob" position="5" length="-1" />
+   <op optype="RemoveAnnotation" memberid="Alice" position="4" length="1" />
+  </ops>
+  <after>
+   <office:text><text:p>ABC<c:cursor c:memberId="Alice"/><c:cursor c:memberId="Bob"/>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>
+  </after>
+ </test>
  <test name="RemoveAnnotation_preservesForeignElements" isFailing="true">
   <before>
    <office:text><text:p>ABC<office:annotation office:name="alice_2"><dc:creator e:memberid="Alice"/><dc:date>2013-08-05T12:34:07.061Z</dc:date><text:list><text:list-item><text:p><foreign:text/></text:p></text:list-item></text:list></office:annotation>D</text:p><text:p>EFG<text:span>HIJ</text:span></text:p></office:text>


### PR DESCRIPTION
Fixes a crash if an annotation being removed has an expanded cursor inside of it.
