### PR TITLE
Recapture focus after clicking on an already selected image 

### DIFF
--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -554,6 +554,7 @@ gui.SessionController = (function () {
             if (target.className === "annotationRemoveButton") {
                 annotationNode = domUtils.getElementsByTagNameNS(target.parentNode, odf.Namespaces.officens, 'annotation')[0];
                 annotationController.removeAnnotation(annotationNode);
+                eventManager.focus();
             } else {
                 handleMouseClickEvent(event);
             }


### PR DESCRIPTION
Clicking on a selected image will lose the event trap focus. Focus needs to be restored back to the event trap after this.

Reproduction of issue:
1) Open http://ci.kogmbh.com/deploy/WebODF/webodf-ci-b165-gf753ec2b/editor/localeditor.html
2) Click on the the image twice
3) hit the delete key. Note that the image is not deleted.
