### PR TITLE
Add ctrl+arrow per-word cursor movement

### DIFF
--- a/webodf/CMakeLists.txt
+++ b/webodf/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TESTJSFILES tests/core/ZipTests.js
     tests/core/RuntimeTests.js
     tests/gui/UndoStateRulesTests.js
     tests/gui/TrivialUndoManagerTests.js
+    tests/gui/SelectionControllerTests.js
     tests/gui/SelectionMoverTests.js
     tests/gui/StyleSummaryTests.js
     tests/odf/OdfUtilsTests.js

--- a/webodf/lib/gui/SelectionController.js
+++ b/webodf/lib/gui/SelectionController.js
@@ -32,7 +32,7 @@
  * @source: http://gitorious.org/webodf/webodf/
  */
 
-/*global runtime, core, gui, odf, ops, Node */
+/*global runtime, core, gui, odf, ops, Node, NodeFilter */
 
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("core.PositionFilterChain");
@@ -55,11 +55,9 @@ gui.SelectionController = function SelectionController(session, inputMemberId) {
         odfUtils = new odf.OdfUtils(),
         baseFilter = odtDocument.getPositionFilter(),
         keyboardMovementsFilter = new core.PositionFilterChain(),
+        movementByWordFilter = new core.PositionFilterChain(),
         rootFilter = odtDocument.createRootFilter(inputMemberId);
-
-    keyboardMovementsFilter.addFilter(baseFilter);
-    keyboardMovementsFilter.addFilter(odtDocument.createRootFilter(inputMemberId));
-
+    
     /**
      * Create a new step iterator with the base Odt filter, and a root filter for the current input member.
      * The step iterator subtree is set to the root of the current cursor node
@@ -464,6 +462,188 @@ gui.SelectionController = function SelectionController(session, inputMemberId) {
             moveCursorByAdjustment(steps);
         }
     }
+    
+    /**
+     * A filter that allows a position if it is in front of a word, picture etc.
+     * @constructor
+     * @param {!number} direction -1 for word beginnings 1 for word endings
+     * @implements {core.PositionFilter}
+     */
+    function WordBoundaryFilter() {
+        var TEXT_NODE = Node.TEXT_NODE,
+            ELEMENT_NODE = Node.ELEMENT_NODE,
+            alphaNumeric = /[A-Za-z0-9]/,
+            spacing = /\s/,
+            /**@const*/
+            FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT,
+            /**@const*/
+            FILTER_REJECT = core.PositionFilter.FilterResult.FILTER_REJECT,
+            /**
+             * @enum {number}
+             */
+            NeighborType = {
+                EDGE:         0,
+                SPACING:      1,
+                PUNCTUATION:  2,
+                WORDCHAR:     3,
+                OTHER:        4
+            };
+            
+        /**
+        * Returns the first filtered sibling ecountered while travelling up the dom from node until
+        * before the documentRoot - or null if none is found.
+        * @param {?Node} node
+        * @param {!number} direction look for a left sibling when negative - for a right sibling otherwise
+        * @param {!function(?Node):!number} nodeFilter
+        * @return {?Node}
+        */
+        function findHigherNeighborNode(node, direction, nodeFilter) {
+            var neighboringNode = null,
+                rootNode = odtDocument.getRootNode(),
+                unfilteredCandidate;
+            
+            while (node !== rootNode && node !== null && neighboringNode === null) {
+                unfilteredCandidate = (direction < 0) ? node.previousSibling : node.nextSibling;
+                if (nodeFilter.acceptNode(unfilteredCandidate) === NodeFilter.FILTER_ACCEPT) {
+                    neighboringNode = unfilteredCandidate;
+                }
+                node = node.parentNode;
+            }
+            
+            return neighboringNode;
+        }
+        
+        /**
+         * @param {?Node} node
+         * @param {!function():!number} getOffset returns the offset inside the node
+         * @return {!NeighborType}
+         */
+        function typeOfNeighbor(node, getOffset) {
+            var neighboringChar;
+            
+            if (node === null) {
+                return NeighborType.EDGE;
+            }
+            if (odfUtils.isCharacterElement(node)) {
+                return NeighborType.SPACING;
+            }
+            if (node.nodeType === TEXT_NODE || odfUtils.isTextSpan(node) || odfUtils.isHyperlink(node)) {
+                neighboringChar = node.textContent.charAt(getOffset());
+                
+                if (spacing.test(neighboringChar)) {
+                    return NeighborType.SPACING;
+                }
+                if (!alphaNumeric.test(neighboringChar)) {
+                    return NeighborType.PUNCTUATION;
+                }
+                return NeighborType.WORDCHAR;
+            }
+            return NeighborType.OTHER;
+        }
+        
+        /**
+         * @param {!core.PositionIterator} iterator
+         * @return {!core.PositionFilter.FilterResult}
+         */
+        this.acceptPosition = function (iterator) {
+            var container = iterator.container(),
+                leftNode = iterator.leftNode(),
+                rightNode = iterator.rightNode(),
+                // For performance reasons, do not calculate the offset inside the dom until it is necessary
+                getRightCharOffset = iterator.unfilteredDomOffset,
+                getLeftCharOffset = function() {return iterator.unfilteredDomOffset() - 1;},
+                leftNeighborType,
+                rightNeighborType;
+            
+            // If this could be the end of an element node, look for the neighboring node higher in the dom
+            if (container.nodeType === ELEMENT_NODE) {
+                if (rightNode === null) {
+                    rightNode = findHigherNeighborNode(container, 1, iterator.getNodeFilter());
+                }
+                if (leftNode === null) {
+                    leftNode = findHigherNeighborNode(container, -1, iterator.getNodeFilter());
+                }
+            }
+            
+            // If we dont stay inside the container node, the getOffset function needs to be modified so as to
+            // return the offset of the characters just at the beginning/end of the respective neighboring node.
+            if (container !== rightNode) {
+                getRightCharOffset = function() {return 0;};
+            }
+            if (container !== leftNode && leftNode !== null) {
+                getLeftCharOffset = function() {return leftNode.textContent.length - 1;};
+            }
+
+            leftNeighborType = typeOfNeighbor(leftNode, getLeftCharOffset);
+            rightNeighborType = typeOfNeighbor(rightNode, getRightCharOffset);
+            
+            // Reject if: is between two usual characters (inside word) OR
+            //            is between two punctuation marks OR
+            //            is before a spacing and not behind the edge (word ending)
+            if ((leftNeighborType === NeighborType.WORDCHAR    && rightNeighborType === NeighborType.WORDCHAR) ||
+                (leftNeighborType === NeighborType.PUNCTUATION && rightNeighborType === NeighborType.PUNCTUATION) ||
+                (leftNeighborType !== NeighborType.EDGE        && rightNeighborType === NeighborType.SPACING)) {
+                return FILTER_REJECT;
+            }
+            return FILTER_ACCEPT;
+        };
+    }
+    
+    /**
+     * @param {!number} direction -1 for left 1 for right
+     * @param {!boolean} extend whether extend the selection instead of moving the cursor
+     * @return {undefined}
+     */
+    function moveCursorByWord(direction, extend) {
+        var stepCounter = odtDocument.getCursor(inputMemberId).getStepCounter(),
+            singleStepsCursorMovementOffset;
+        
+        singleStepsCursorMovementOffset = (direction >= 0)
+            ? stepCounter.convertForwardStepsBetweenFilters(1, movementByWordFilter, keyboardMovementsFilter)
+            : -stepCounter.convertBackwardStepsBetweenFilters(1, movementByWordFilter, keyboardMovementsFilter);
+        
+        if (extend) {
+            extendCursorByAdjustment(singleStepsCursorMovementOffset);
+        } else {
+            moveCursorByAdjustment(singleStepsCursorMovementOffset);
+        }
+    }
+    
+    /**
+     * @return {!boolean}
+     */
+    function moveCursorBeforeWord() {
+        moveCursorByWord(-1, false);
+        return true;
+    }
+    this.moveCursorBeforeWord = moveCursorBeforeWord;
+
+    /**
+     * @return {!boolean}
+     */
+    function moveCursorPastWord() {
+        moveCursorByWord(1, false);
+        return true;
+    }
+    this.moveCursorPastWord = moveCursorPastWord;
+
+    /**
+     * @return {!boolean}
+     */
+    function extendSelectionBeforeWord() {
+        moveCursorByWord(-1, true);
+        return true;
+    }
+    this.extendSelectionBeforeWord = extendSelectionBeforeWord;
+
+    /**
+     * @return {!boolean}
+     */
+    function extendSelectionPastWord() {
+        moveCursorByWord(1, true);
+        return true;
+    }
+    this.extendSelectionPastWord = extendSelectionPastWord;
 
     /**
      * @return {!boolean}
@@ -626,4 +806,15 @@ gui.SelectionController = function SelectionController(session, inputMemberId) {
         return true;
     }
     this.extendSelectionToEntireDocument = extendSelectionToEntireDocument;
+    
+    /**
+     * @return {undefined}
+     */
+    function init() {
+        keyboardMovementsFilter.addFilter(baseFilter);
+        keyboardMovementsFilter.addFilter(odtDocument.createRootFilter(inputMemberId));
+        movementByWordFilter.addFilter(keyboardMovementsFilter);
+        movementByWordFilter.addFilter(new WordBoundaryFilter());
+    }
+    init();
 };

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -874,7 +874,6 @@ gui.SessionController = (function () {
             keyDownHandler.bind(keyCode.Right, modifier.Shift, rangeSelectionOnly(selectionController.extendSelectionToRight));
             keyDownHandler.bind(keyCode.Up, modifier.Shift, rangeSelectionOnly(selectionController.extendSelectionUp));
             keyDownHandler.bind(keyCode.Down, modifier.Shift, rangeSelectionOnly(selectionController.extendSelectionDown));
-
             keyDownHandler.bind(keyCode.Home, modifier.None, rangeSelectionOnly(selectionController.moveCursorToLineStart));
             keyDownHandler.bind(keyCode.End, modifier.None, rangeSelectionOnly(selectionController.moveCursorToLineEnd));
             keyDownHandler.bind(keyCode.Home, modifier.Ctrl, rangeSelectionOnly(selectionController.moveCursorToDocumentStart));
@@ -887,10 +886,14 @@ gui.SessionController = (function () {
             keyDownHandler.bind(keyCode.End, modifier.CtrlShift, rangeSelectionOnly(selectionController.extendSelectionToDocumentEnd));
 
             if (isMacOS) {
+                keyDownHandler.bind(keyCode.Left, modifier.Alt, rangeSelectionOnly(selectionController.moveCursorBeforeWord));
+                keyDownHandler.bind(keyCode.Right, modifier.Alt, rangeSelectionOnly(selectionController.moveCursorPastWord));
                 keyDownHandler.bind(keyCode.Left, modifier.Meta, rangeSelectionOnly(selectionController.moveCursorToLineStart));
                 keyDownHandler.bind(keyCode.Right, modifier.Meta, rangeSelectionOnly(selectionController.moveCursorToLineEnd));
                 keyDownHandler.bind(keyCode.Home, modifier.Meta, rangeSelectionOnly(selectionController.moveCursorToDocumentStart));
                 keyDownHandler.bind(keyCode.End, modifier.Meta, rangeSelectionOnly(selectionController.moveCursorToDocumentEnd));
+                keyDownHandler.bind(keyCode.Left, modifier.AltShift, rangeSelectionOnly(selectionController.extendSelectionBeforeWord));
+                keyDownHandler.bind(keyCode.Right, modifier.AltShift, rangeSelectionOnly(selectionController.extendSelectionPastWord));
                 keyDownHandler.bind(keyCode.Left, modifier.MetaShift, rangeSelectionOnly(selectionController.extendSelectionToLineStart));
                 keyDownHandler.bind(keyCode.Right, modifier.MetaShift, rangeSelectionOnly(selectionController.extendSelectionToLineEnd));
                 keyDownHandler.bind(keyCode.Up, modifier.AltShift, rangeSelectionOnly(selectionController.extendSelectionToParagraphStart));
@@ -899,6 +902,10 @@ gui.SessionController = (function () {
                 keyDownHandler.bind(keyCode.Down, modifier.MetaShift, rangeSelectionOnly(selectionController.extendSelectionToDocumentEnd));
                 keyDownHandler.bind(keyCode.A, modifier.Meta, rangeSelectionOnly(selectionController.extendSelectionToEntireDocument));
             } else {
+                keyDownHandler.bind(keyCode.Left, modifier.Ctrl, rangeSelectionOnly(selectionController.moveCursorBeforeWord));
+                keyDownHandler.bind(keyCode.Right, modifier.Ctrl, rangeSelectionOnly(selectionController.moveCursorPastWord));
+                keyDownHandler.bind(keyCode.Left, modifier.CtrlShift, rangeSelectionOnly(selectionController.extendSelectionBeforeWord));
+                keyDownHandler.bind(keyCode.Right, modifier.CtrlShift, rangeSelectionOnly(selectionController.extendSelectionPastWord));
                 keyDownHandler.bind(keyCode.A, modifier.Ctrl, rangeSelectionOnly(selectionController.extendSelectionToEntireDocument));
             }
 

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -159,7 +159,9 @@
     ],
     "gui/SelectionController.js": [
         "core/DomUtils.js",
+        "core/PositionFilter.js",
         "core/PositionFilterChain.js",
+        "core/PositionIterator.js",
         "core/StepIterator.js",
         "gui/SelectionMover.js",
         "odf/OdfUtils.js",

--- a/webodf/tests/gui/SelectionControllerTests.js
+++ b/webodf/tests/gui/SelectionControllerTests.js
@@ -1,0 +1,308 @@
+/**
+ * Copyright (C) 2014 KO GmbH <copyright@kogmbh.com>
+ * @licstart
+ * The JavaScript code in this page is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.  The code is distributed
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As additional permission under GNU AGPL version 3 section 7, you
+ * may distribute non-source (e.g., minimized or compacted) forms of
+ * that code without the copy of the GNU GPL normally required by
+ * section 4, provided you include this license notice and a URL
+ * through which recipients can access the Corresponding Source.
+ *
+ * As a special exception to the AGPL, any HTML file which merely makes function
+ * calls to this code, and for that purpose includes it by reference shall be
+ * deemed a separate work for copyright law purposes. In addition, the copyright
+ * holders of this code give you permission to combine this code with free
+ * software libraries that are released under the GNU LGPL. You may copy and
+ * distribute such a system following the terms of the GNU AGPL for this code
+ * and the LGPL for the libraries. If you modify this code, you may extend this
+ * exception to your version of the code, but you are not obligated to do so.
+ * If you do not wish to do so, delete this exception statement from your
+ * version.
+ *
+ * This license applies to this entire compilation.
+ * @licend
+ * @source: http://www.webodf.org/
+ * @source: https://github.com/kogmbh/WebODF/
+ */
+/*global runtime, core, gui, odf, ops, Node, NodeFilter, xmldom*/
+runtime.loadClass("xmldom.LSSerializer");
+runtime.loadClass("odf.Namespaces");
+runtime.loadClass("gui.SelectionController");
+runtime.loadClass("ops.OdtDocument");
+runtime.loadClass("ops.OdtCursor");
+/**
+ * @constructor
+ * @param {core.UnitTestRunner} runner
+ * @implements {core.UnitTest}
+ */
+gui.SelectionControllerTests = function SelectionControllerTests(runner) {
+    "use strict";
+    var r = runner,
+        t,
+        testarea,
+        inputMemberId = "Joe";
+
+    /**
+     * Trying to avoid having to load a complete document for these tests. Mocking ODF
+     * canvas allows some simplification in the testing setup
+     * @param {Element} node
+     * @extends {odf.OdfCanvas} Well.... we don't really, but please shut your face closure compiler :)
+     * @constructor
+     */
+    function MockOdfCanvas(node) {
+        var self = this;
+        this.odfContainer = function () { return self; };
+        this.getContentElement = function () { return node.getElementsByTagNameNS(odf.Namespaces.officens, 'text')[0]; };
+    }
+
+    /**
+     * @param {!ops.OdtDocument} odtDocument
+     * @extends {ops.Session} Don't mind me... I'm just lying to closure compiler again!
+     * @constructor
+     */
+    function MockSession(odtDocument) {
+        var self = this;
+        this.operations = [];
+
+        this.getOdtDocument = function() {
+            return odtDocument;
+        };
+
+        this.enqueue = function(ops) {
+            self.operations.push.apply(self.operations, ops);
+            ops.forEach(function(op) { op.execute(odtDocument); });
+        };
+
+        this.reset = function() {
+            self.operations.length = 0;
+        };
+    }
+
+    /**
+     * Create a new ODT document with the specified text body
+     * @param {!string} xml
+     * @returns {!Element} Root document node
+     */
+    function createOdtDocument(xml) {
+        var domDocument = testarea.ownerDocument,
+            doc = core.UnitTest.createOdtDocument("<office:text>" + xml + "</office:text>", odf.Namespaces.namespaceMap),
+            node = /**@type{!Element}*/(domDocument.importNode(doc.documentElement, true));
+
+        testarea.appendChild(node);
+
+        t.odtDocument = new ops.OdtDocument(new MockOdfCanvas(node));
+        t.session = new MockSession(t.odtDocument);
+        t.selectionController = new gui.SelectionController(t.session, inputMemberId);
+        t.cursor = new ops.OdtCursor(inputMemberId, t.odtDocument);
+        t.odtDocument.addCursor(t.cursor);
+        return node;
+    }
+
+    /**
+     * Find and return an array of numbers indicating each move cursor operation's position as it
+     * iterates over the document content.
+     * @param {!string} docContent Odt content
+     * @param {!number} direction if negative, iterate from right to left over the document instead of left to right
+     * @returns {!Array.<!number>} valid cursor positions within the specified doc content
+     */
+    function getMovementByWordsPositions(docContent, direction) {
+        var bounds = [],
+            loopGuard = new core.LoopWatchDog(100000, 100), // Don't care really how long this takes
+            lastSpec,
+            generatedOps = false;
+
+        createOdtDocument(docContent);
+        if(direction < 0) {
+            t.selectionController.moveCursorToDocumentEnd();
+        }
+        t.session.reset();
+        do {
+            loopGuard.check();
+            if(direction < 0) {
+                t.selectionController.moveCursorBeforeWord();
+            } else {
+                t.selectionController.moveCursorPastWord();
+            }
+            generatedOps = t.session.operations.length > 0;
+            if (generatedOps) {
+                // Only ever expect a single operation to be queued here
+                lastSpec = t.session.operations[0].spec();
+                bounds.push(lastSpec.position);
+                t.session.reset();
+            }
+        } while(generatedOps);
+
+        return bounds;
+    }
+
+    function moveCursorPastWord_SimpleText() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the quick red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_SimpleText() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the quick red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_SimpleText_Punctuation() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the quick, re,d fox.</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 9, 11, 13, 14, 16, 19, 20]");
+    }
+
+    function moveCursorBeforeWord_SimpleText_Punctuation() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the quick, re,d fox.</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[19, 16, 14, 13, 11, 9, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextSplitBySpans() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the q<text:span>uick</text:span> red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_TextSplitBySpans() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the q<text:span>uick</text:span> red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextWithinSpan() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:span>quick</text:span> <text:span>red.</text:span> fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 13, 15, 18]");
+    }
+
+    function moveCursorBeforeWord_TextWithinSpan() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:span>quick</text:span> <text:span>red.</text:span> fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[15, 13, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextWithinSpan_2() {
+        t.movementPositions = getMovementByWordsPositions("<text:p><text:span>the quick</text:span> red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_TextWithinSpan_2() {
+        t.movementPositions = getMovementByWordsPositions("<text:p><text:span>the quick</text:span> red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextWithinSpan_3() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:span>quick,</text:span> <text:span>re,</text:span>d fox.</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 9, 11, 13, 14, 16, 19, 20]");
+    }
+
+    function moveCursorBeforeWord_TextWithinSpan_3() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:span>quick,</text:span> <text:span>re,</text:span>d fox.</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[19, 16, 14, 13, 11, 9, 4, 0]");
+    }
+
+    function moveCursorPastWord_WordStartsNextToSpan() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:span>quick </text:span>red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_WordStartsNextToSpan() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:span>quick </text:span>red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextSplitByLink() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the q<text:a>uick</text:a> red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_TextSplitByLink() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the q<text:a>uick</text:a> red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextWithinLink() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:a>quick</text:a> red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_TextWithinLink() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:a>quick</text:a> red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorPastWord_TextWithinLinkAndSpan() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:a>q</text:a><text:a><text:span>u</text:span></text:a>ick red fox</text:p>", 1);
+        r.shouldBe(t, "t.movementPositions", "[4, 10, 14, 17]");
+    }
+
+    function moveCursorBeforeWord_TextWithinLinkAndSpan() {
+        t.movementPositions = getMovementByWordsPositions("<text:p>the <text:a>q</text:a><text:a><text:span>u</text:span></text:a>ick red fox</text:p>", -1);
+        r.shouldBe(t, "t.movementPositions", "[14, 10, 4, 0]");
+    }
+
+    function moveCursorToDocumentEnd_Simple() {
+        t.position = undefined;
+        createOdtDocument("<text:p>the <text:a>q</text:a><text:a><text:span>u</text:span></text:a>ick red fox</text:p>");
+
+        t.selectionController.moveCursorToDocumentEnd();
+
+        if(t.session.operations.length > 0) {
+            t.position = t.session.operations[0].spec().position;
+        }
+        r.shouldBe(t, "t.position", "17");
+    }
+
+    this.setUp = function () {
+        testarea = core.UnitTest.provideTestAreaDiv();
+        t = { doc: testarea.ownerDocument };
+    };
+    this.tearDown = function () {
+        core.UnitTest.cleanupTestAreaDiv();
+        t = {};
+    };
+
+    this.tests = function () {
+        return r.name([
+            moveCursorPastWord_SimpleText,
+            moveCursorBeforeWord_SimpleText,
+            moveCursorPastWord_SimpleText_Punctuation,
+            moveCursorBeforeWord_SimpleText_Punctuation,
+
+            moveCursorPastWord_TextSplitBySpans,
+            moveCursorBeforeWord_TextSplitBySpans,
+            moveCursorPastWord_TextWithinSpan,
+            moveCursorBeforeWord_TextWithinSpan,
+            moveCursorPastWord_TextWithinSpan_2,
+            moveCursorBeforeWord_TextWithinSpan_2,
+            moveCursorPastWord_TextWithinSpan_3,
+            moveCursorBeforeWord_TextWithinSpan_3,
+            moveCursorPastWord_WordStartsNextToSpan,
+            moveCursorBeforeWord_WordStartsNextToSpan,
+
+            moveCursorPastWord_TextSplitByLink,
+            moveCursorBeforeWord_TextSplitByLink,
+            moveCursorPastWord_TextWithinLink,
+            moveCursorBeforeWord_TextWithinLink,
+            moveCursorPastWord_TextWithinLinkAndSpan,
+            moveCursorBeforeWord_TextWithinLinkAndSpan,
+
+            moveCursorToDocumentEnd_Simple
+        ]);
+    };
+    this.asyncTests = function () {
+        return [
+        ];
+    };
+};
+gui.SelectionControllerTests.prototype.description = function () {
+    "use strict";
+    return "Test the SelectionController class.";
+};
+(function () {
+    "use strict";
+    return gui.SelectionControllerTests;
+}());

--- a/webodf/tests/manifest.json
+++ b/webodf/tests/manifest.json
@@ -30,6 +30,17 @@
         "core/UnitTester.js",
         "core/Zip.js"
     ],
+    "gui/SelectionControllerTests.js": [
+        "core/LoopWatchDog.js",
+        "core/UnitTester.js",
+        "gui/SelectionController.js",
+        "odf/Namespaces.js",
+        "odf/OdfCanvas.js",
+        "ops/OdtCursor.js",
+        "ops/OdtDocument.js",
+        "ops/Session.js",
+        "xmldom/LSSerializer.js"
+    ],
     "gui/SelectionMoverTests.js": [
         "core/Cursor.js",
         "core/PositionFilter.js",

--- a/webodf/tests/tests.js
+++ b/webodf/tests/tests.js
@@ -45,6 +45,7 @@ runtime.loadClass("core.UnitTester");
 runtime.loadClass("core.ZipTests");
 runtime.loadClass("gui.UndoStateRulesTests");
 runtime.loadClass("gui.TrivialUndoManagerTests");
+runtime.loadClass("gui.SelectionControllerTests");
 runtime.loadClass("gui.SelectionMoverTests");
 runtime.loadClass("gui.StyleSummaryTests");
 runtime.loadClass("ops.OdtCursorTests");
@@ -89,6 +90,7 @@ if (runtime.getDOMImplementation() && runtime.parseXML("<a/>").createRange) {
     tests.push(core.StepIteratorTests);
     tests.push(gui.UndoStateRulesTests);
     tests.push(gui.TrivialUndoManagerTests);
+    tests.push(gui.SelectionControllerTests);
     tests.push(gui.SelectionMoverTests);
     tests.push(gui.StyleSummaryTests);
     tests.push(odf.OdfUtilsTests);


### PR DESCRIPTION
This adds moving the cursor word by word by pressing ctrl+left-arrow/right-arrow. When additionally pressing the shift key, the current selection is extended on a per-word basis. (resolves #120)
