### PR TITLE
Improve the performance of undo ops grouping on large states

### DIFF
--- a/webodf/tests/gui/UndoStateRulesTests.js
+++ b/webodf/tests/gui/UndoStateRulesTests.js
@@ -326,9 +326,9 @@ gui.UndoStateRulesTests = function UndoStateRulesTests(runner) {
         t.ops = [
             create(new ops.OpInsertText(), {position: 0, text: "abcde"}, "g1"),
             create(new ops.OpRemoveText(), {position: 3, length: 1}, "g1"), // Delete d
-            create(new ops.OpRemoveText(), {position: 3, length: 1}, "g2"), // Delete e
+            create(new ops.OpRemoveText(), {position: 1, length: 1}, "g2"), // Delete b
             create(new ops.OpRemoveText(), {position: 0, length: 1}, "g2"), // Delete a
-            create(new ops.OpRemoveText(), {position: 0, length: 1}, "g2") // Delete b
+            create(new ops.OpRemoveText(), {position: 0, length: 1}, "g2") // Delete c
         ];
 
         t.previousState = findLastUndoState(t.ops);


### PR DESCRIPTION
Continuous typing causes the undo states to potentially become extremely large. The naive assumption that some of the arrays in use would stay small causes immense slow-downs when determining whether to create a new undo state.

These bottlenecks have now been removed, and the search depth of various grouping conditions have been limited to psmaller sizes.
