### PR TITLE
Cache calculated style information when applying direct formatting

### DIFF
--- a/webodf/lib/odf/TextStyleApplicator.js
+++ b/webodf/lib/odf/TextStyleApplicator.js
@@ -65,6 +65,8 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
      * @param {!Object} info Style information
      */
     function StyleLookup(info) {
+        var cachedAppliedStyles = {};
+
         /**
          * @param {!Object} expected
          * @param {Object|undefined} actual
@@ -84,10 +86,8 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
          * @return {boolean}
          */
         this.isStyleApplied = function (textNode) {
-            // TODO make this performant...
-            // TODO take into account defaults and don't require styles if re-iterating the default impacts
             // TODO can direct style to element just be removed somewhere to end up with desired style?
-            var appliedStyle = formatting.getAppliedStylesForElement(textNode);
+            var appliedStyle = formatting.getAppliedStylesForElement(textNode, cachedAppliedStyles);
             return compare(info, appliedStyle);
         };
     }


### PR DESCRIPTION
When direct formatting, often extremely similar (if not identical) style hierarchies are being continually retrieved. Allowing external consumers to provide a limited-life cache vastly speeds up the lookup for this data.

(Note, the impact of PR 321 dwarfs this at 1000 pages, but the extra 3s becomes more significant as more improvements are made)
### 1000page.odt - Bold the current selection

|  | Master (ms) | PR 321 (ms) | PR 321 + 326 (ms) |
| --- | --- | --- | --- |
| Chrome | 416651 | 42446 | 38806 |
