### PR TITLE
Only re-render the selection overlay once per batch of requests

### DIFF
--- a/webodf/lib/gui/SelectionView.js
+++ b/webodf/lib/gui/SelectionView.js
@@ -61,12 +61,6 @@ gui.SelectionView.prototype.show = function() { "use strict"; };
 gui.SelectionView.prototype.hide = function() { "use strict"; };
 
 /**
- * Returns if the selection view is visible or hidden
- * @return {undefined}
- */
-gui.SelectionView.prototype.visible = function() { "use strict"; };
-
-/**
  * Clear all overlay from the DOM
  * @param {function(?string)} callback
  * @return {undefined}

--- a/webodf/lib/gui/SelectionViewManager.js
+++ b/webodf/lib/gui/SelectionViewManager.js
@@ -109,9 +109,7 @@ gui.SelectionViewManager = function SelectionViewManager(SelectionView) {
      */
     this.rerenderSelectionViews = function () {
         Object.keys(selectionViews).forEach(function (memberId) {
-            if(selectionViews[memberId].visible()) {
-                selectionViews[memberId].rerender();
-            }
+            selectionViews[memberId].rerender();
         });
     };
 

--- a/webodf/lib/gui/SessionView.js
+++ b/webodf/lib/gui/SessionView.js
@@ -98,10 +98,7 @@ gui.SessionView = (function () {
             editInfoMap = {},
             showEditInfoMarkers = configOption(viewOptions.editInfoMarkersInitiallyVisible, true),
             showCaretAvatars = configOption(viewOptions.caretAvatarsInitiallyVisible, true),
-            blinkOnRangeSelect = configOption(viewOptions.caretBlinksOnRangeSelect, true),
-            rerenderIntervalId,
-            rerenderSelectionViews = false,
-            /**@const*/RERENDER_INTERVAL = 200; // milliseconds
+            blinkOnRangeSelect = configOption(viewOptions.caretBlinksOnRangeSelect, true);
 
         /**
          * @param {!string} nodeName
@@ -375,33 +372,6 @@ gui.SessionView = (function () {
         }
 
         /**
-         * @return {undefined}
-         */
-        function requestRerenderOfSelectionViews() {
-            rerenderSelectionViews = true;
-        }
-
-        /**
-         * Starts an interval loop that rerenders selection views and whatever else
-         * needs refreshing every RERENDER_INTERVAL milliseconds.
-         * @return {undefined}
-         */
-        function startRerenderLoop() {
-            rerenderIntervalId = runtime.getWindow().setInterval(function () {
-                if (rerenderSelectionViews) {
-                    selectionViewManager.rerenderSelectionViews();
-                    rerenderSelectionViews = false;
-                }
-            }, RERENDER_INTERVAL);
-        }
-        /**
-         * Stops the rerender loop.
-         */
-        function stopRerenderLoop() {
-            runtime.getWindow().clearInterval(rerenderIntervalId);
-        }
-
-        /**
          * @param {!function(!Object=)} callback, passing an error object in case of error
          * @return {undefined}
          */
@@ -416,11 +386,9 @@ gui.SessionView = (function () {
             odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
             odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
 
-            odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, requestRerenderOfSelectionViews);
-            odtDocument.unsubscribe(ops.OdtDocument.signalTableAdded, requestRerenderOfSelectionViews);
-            odtDocument.unsubscribe(ops.OdtDocument.signalParagraphStyleModified, requestRerenderOfSelectionViews);
-
-            stopRerenderLoop();
+            odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, selectionViewManager.rerenderSelectionViews);
+            odtDocument.unsubscribe(ops.OdtDocument.signalTableAdded, selectionViewManager.rerenderSelectionViews);
+            odtDocument.unsubscribe(ops.OdtDocument.signalParagraphStyleModified, selectionViewManager.rerenderSelectionViews);
 
             avatarInfoStyles.parentNode.removeChild(avatarInfoStyles);
 
@@ -448,11 +416,9 @@ gui.SessionView = (function () {
             odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
             odtDocument.subscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
 
-            startRerenderLoop();
-
-            odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, requestRerenderOfSelectionViews);
-            odtDocument.subscribe(ops.OdtDocument.signalTableAdded, requestRerenderOfSelectionViews);
-            odtDocument.subscribe(ops.OdtDocument.signalParagraphStyleModified, requestRerenderOfSelectionViews);
+            odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, selectionViewManager.rerenderSelectionViews);
+            odtDocument.subscribe(ops.OdtDocument.signalTableAdded, selectionViewManager.rerenderSelectionViews);
+            odtDocument.subscribe(ops.OdtDocument.signalParagraphStyleModified, selectionViewManager.rerenderSelectionViews);
 
             // Add a css sheet for user info-edited styling
             avatarInfoStyles = document.createElementNS(head.namespaceURI, 'style');

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -238,7 +238,9 @@
     "gui/StyleSummary.js": [
     ],
     "gui/SvgSelectionView.js": [
+        "core/Async.js",
         "core/DomUtils.js",
+        "core/ScheduledTask.js",
         "gui/SelectionMover.js",
         "gui/SelectionView.js",
         "gui/ShadowCursor.js",


### PR DESCRIPTION
Also, decrease the maximum latency between a render request and when the update is performed to be 0ms. The previous value of 200ms was quite noticeable when indenting or unindenting paragraphs.
# Performance

@ 1000pages.odt - Chrome

|  | master 0b4f6a6 (ms) | pr 329 (ms) |
| --- | --- | --- |
| Select the entire document | 1848 | 721 |
| Bold the current selection | 6992 | 6014 |
