### PR TITLE
Enable Virtual Selections in Viewer

### DIFF
--- a/programs/viewer/CMakeLists.txt
+++ b/programs/viewer/CMakeLists.txt
@@ -53,6 +53,7 @@ add_custom_command(
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/../../webodf/webodf.js ${VIEWERBUILDDIR}/webodf.js
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/viewer-minimized.js ${VIEWERBUILDDIR}/viewer.js
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/index.html ${VIEWERBUILDDIR}/index.html
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/ODFViewerPlugin.css ${VIEWERBUILDDIR}/ODFViewerPlugin.css
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/ODFViewerPlugin.js ${VIEWERBUILDDIR}/ODFViewerPlugin.js
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/PluginLoader.js ${VIEWERBUILDDIR}/PluginLoader.js
     COMMAND ${CMAKE_COMMAND} -E copy ${LIBJSLICENSEFILE} ${VIEWERBUILDDIR}
@@ -63,6 +64,7 @@ add_custom_command(
         index.html
         PluginLoader.js
         ODFViewerPlugin.js
+        ODFViewerPlugin.css
         webodf.js-target
         viewer-minimized.js-target
 )

--- a/programs/viewer/ODFViewerPlugin.css
+++ b/programs/viewer/ODFViewerPlugin.css
@@ -1,0 +1,5 @@
+@namespace cursor url(urn:webodf:names:cursor);
+
+span.caret {
+    opacity: 0 !important;
+}

--- a/programs/viewer/ODFViewerPlugin.js
+++ b/programs/viewer/ODFViewerPlugin.js
@@ -42,7 +42,9 @@ function ODFViewerPlugin() {
     "use strict";
 
     function init(callback) {
-        var lib = document.createElement('script');
+        var lib = document.createElement('script'),
+            pluginCSS;
+
         lib.async = false;
         lib.src = './webodf.js';
         lib.type = 'text/javascript';
@@ -56,10 +58,24 @@ function ODFViewerPlugin() {
 
             runtime.loadClass('gui.HyperlinkClickHandler');
             runtime.loadClass('odf.OdfCanvas');
+            runtime.loadClass('ops.Session');
+            runtime.loadClass('gui.CaretManager');
+            runtime.loadClass('gui.SessionController');
+            runtime.loadClass('gui.SvgSelectionView');
+            runtime.loadClass('gui.SelectionViewManager');
+            runtime.loadClass('gui.ShadowCursor');
+            runtime.loadClass('gui.SessionView');
+
             callback();
         };
 
         document.getElementsByTagName('head')[0].appendChild(lib);
+
+        pluginCSS = document.createElement('link');
+        pluginCSS.setAttribute("rel", "stylesheet");
+        pluginCSS.setAttribute("type", "text/css");
+        pluginCSS.setAttribute("href", "./ODFViewerPlugin.css");
+        document.head.appendChild(pluginCSS);
     }
 
     // that should probably be provided by webodf
@@ -87,7 +103,16 @@ function ODFViewerPlugin() {
     this.initialize = function (viewerElement, documentUrl) {
         // If the URL has a fragment (#...), try to load the file it represents
         init(function () {
-            var hyperlinkClickHandler;
+            var hyperlinkClickHandler,
+                session,
+                sessionController,
+                sessionView,
+                odtDocument,
+                shadowCursor,
+                selectionViewManager,
+                caretManager,
+                localMemberId = 'localuser';
+
             odfElement = document.getElementById('canvas');
             odfCanvas = new odf.OdfCanvas(odfElement);
             odfCanvas.load(documentUrl);
@@ -98,7 +123,30 @@ function ODFViewerPlugin() {
                 documentType = odfCanvas.odfContainer().getDocumentType(root);
                 if (documentType === 'text') {
                     odfCanvas.enableAnnotations(true, false);
+
+                    session = new ops.Session(odfCanvas);
+                    odtDocument = session.getOdtDocument();
+                    shadowCursor = new gui.ShadowCursor(odtDocument);
+                    sessionController = new gui.SessionController(session, localMemberId, shadowCursor, {});
+                    caretManager = new gui.CaretManager(sessionController);
+                    selectionViewManager = new gui.SelectionViewManager(gui.SvgSelectionView);
+                    sessionView = new gui.SessionView({
+                        caretAvatarsInitiallyVisible: false
+                    }, localMemberId, session, caretManager, selectionViewManager);
+                    selectionViewManager.registerCursor(shadowCursor);
+
+                    var op = new ops.OpAddMember();
+                    op.init({
+                        memberid: localMemberId,
+                        setProperties: {
+                            fillName: runtime.tr("Unknown Author"),
+                            color: "blue"
+                        }
+                    });
+                    session.enqueue([op]);
+                    sessionController.registerLocalCursor();
                 }
+
                 self.onLoad();
             });
 


### PR DESCRIPTION
This PR uses a simple way to enable virtual selections in the viewer by initializing all the required editing modules, just falling short of calling `sessionController.startEditing()`.

This lets the shadow cursor and normal local cursor be movable by mouse or keyboard.
An additional `ODFViewerPlugin.css` file is added (just like the corresponding css file for the PDF backend in ViewerJS) that hides the caret and avatar handle for the local cursor.

Also fixes another issue: the `class` attribute of the avatar handle div was being used to mark the focus state. This state is now expressed by an `focus` attribute that can take the values `"active"` or `"disabled"`. The `class` is reserved for the `"handle"`.

I do not consider this solution optimal; I'd rather enable the VS/cursor movements through a constraints system. But till that is really ready, this ought to do.
