### PR TITLE
Ensure caret is destroyed when corresponding cursor is removed

### DIFF
--- a/webodf/lib/gui/Caret.js
+++ b/webodf/lib/gui/Caret.js
@@ -90,10 +90,6 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
      * @return {undefined}
      */
     function blinkCaret() {
-        if (!cursorNode.parentNode) {
-            // stop blinking when removed from the document
-            return;
-        }
         // switch between transparent and color
         span.style.opacity = span.style.opacity === "0" ? "1" : "0";
         blinkTask.trigger(); // Trigger next blink to occur in BLINK_PERIOD_MS

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -73,6 +73,7 @@
         "ops/OdtCursor.js"
     ],
     "gui/CaretManager.js": [
+        "core/Async.js",
         "gui/Caret.js",
         "gui/SessionController.js",
         "ops/OdtCursor.js",


### PR DESCRIPTION
When a cursor is removed from the document, the associated caret should also be destroyed. This prevents stale timers from attempting to update the style on detached nodes, which causes crashes in some browsers (e.g., WebKit in Cocoa on OSX10.8).
