### PR TITLE
Ensure the event trap has a minimum height

### DIFF
--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -290,7 +290,8 @@ cursor|cursor > #eventTrap {
     right: 0;
     color: rgba(255, 255, 255, 0); /* hide the blinking caret by setting the colour to fully transparent */
     overflow: hidden; /* The overflow visibility is used to hide and show characters being entered */
-    height: auto;
+    min-height: 1px; /* trap must be visible in order to receive focus */
+    height: auto; /* but ideally is the same height as the surrounding cursor */
     width: 1px; /* trap must be visible in order to receive focus */
 }
 


### PR DESCRIPTION
0px height elements are not able to receive an active selection in most browsers. Setting a minimum height ensures the event trap is still able to be selected when in an empty paragraph.
