### PR TITLE
Don't re-order non-ODF children when merging paragraphs

### DIFF
--- a/webodf/lib/ops/OpRemoveText.js
+++ b/webodf/lib/ops/OpRemoveText.js
@@ -183,14 +183,12 @@ ops.OpRemoveText = function OpRemoveText() {
      */
     function mergeParagraphs(first, second, collapseRules) {
         var child,
-            mergeForward = false,
             destination = first,
             source = second,
             secondParent,
             insertionPoint = null;
 
         if (collapseRules.isEmpty(first)) {
-            mergeForward = true;
             if (second.parentNode !== first.parentNode) {
                 // We're just about to move the second paragraph in to the right position for the merge.
                 // Therefore, we need to remember if the second paragraph is from a different parent in order to clean
@@ -203,8 +201,8 @@ ops.OpRemoveText = function OpRemoveText() {
             insertionPoint = destination.getElementsByTagNameNS(editinfons, 'editinfo')[0] || destination.firstChild;
         }
 
-        while (source.hasChildNodes()) {
-            child = mergeForward ? source.lastChild : source.firstChild;
+        while (source.firstChild) {
+            child = source.firstChild;
             source.removeChild(child);
             if (child.localName !== 'editinfo') {
                 destination.insertBefore(child, insertionPoint);

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -602,6 +602,13 @@
   </ops>
   <after><office:text><text:p text:style-name="B">efgh</text:p></office:text></after>
  </test>
+ <test name="Remove_deleteMergeEmpty_WithNonOdfChildren">
+  <before><office:text><text:p text:style-name="A"><foreign:test foreign:id="1"/><foreign:test foreign:id="2"/></text:p><text:p text:style-name="B"><foreign:test foreign:id="3"/>efgh<foreign:test foreign:id="4"/></text:p></office:text></before>
+  <ops>
+   <op optype="RemoveText" position="0" length="1"/>
+  </ops>
+  <after><office:text><text:p text:style-name="B"><foreign:test foreign:id="1"/><foreign:test foreign:id="2"/><foreign:test foreign:id="3"/>efgh<foreign:test foreign:id="4"/></text:p></office:text></after>
+ </test>
  <test name="Remove_deleteLink1">
   <before><office:text><text:p><text:a xlink:type="simple" xlink:href="http://www.hello.com"><text:span>Hello</text:span></text:a></text:p></office:text></before>
   <ops>


### PR DESCRIPTION
Child order of non-ODF nodes should be preserved when merging paragraphs.
