### PR TITLE
Run updateJS.js every time the build system is invoked.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,12 +260,10 @@ endif(NOT ANDROID_SDK_DIR)
 
 set(LIBJSLICENSEFILE ${CMAKE_CURRENT_SOURCE_DIR}/AGPL-3.0.txt)
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/jsfileslist.txt)
-  execute_process(
-    COMMAND ${NODE} lib/runtime.js tools/updateJS.js ${CMAKE_BINARY_DIR}/jsfileslist.txt
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/webodf
-  )
-endif(NOT EXISTS ${CMAKE_BINARY_DIR}/jsfileslist.txt)
+execute_process(
+  COMMAND ${NODE} lib/runtime.js tools/updateJS.js ${CMAKE_BINARY_DIR}/jsfileslist.txt
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/webodf
+)
 include(${CMAKE_BINARY_DIR}/jsfileslist.txt)
 set(LIBJSFILES ${TYPEDLIBJSFILES} ${UNTYPEDLIBJSFILES})
 

--- a/webodf/CMakeLists.txt
+++ b/webodf/CMakeLists.txt
@@ -36,12 +36,6 @@ set(TESTJSFILES tests/core/ZipTests.js
     tests/tests.js
 )
 
-add_custom_target(manifest.json-target
-    COMMAND ${NODE}
-    lib/runtime.js tools/updateJS.js ${CMAKE_BINARY_DIR}/jsfileslist.txt
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
 add_custom_command(
     OUTPUT webodf.css.js
     COMMAND "${NODE}"

--- a/webodf/tests/CMakeLists.txt
+++ b/webodf/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ COPY_FILES(tests_nodetests ${CMAKE_CURRENT_SOURCE_DIR}
 add_custom_target(nodetest ALL
 	COMMAND ${NODE} ${RUNTIME} ./tests.js
 	WORKING_DIRECTORY _nodetest
-    DEPENDS NodeJS ${tests_nodetests} manifest.json-target
+    DEPENDS NodeJS ${tests_nodetests}
 )
 
 if (QT4_FOUND)
@@ -25,7 +25,7 @@ if (QT4_FOUND)
 	add_custom_target(qtjsruntimetest ALL
 		COMMAND ${CMAKE_BINARY_DIR}/programs/qtjsruntime/qtjsruntime ${RUNTIME} ./tests.js
 		WORKING_DIRECTORY _qtjsruntimetest
-		DEPENDS NodeJS ${tests_qtjsruntimetest} qtjsruntime manifest.json-target
+		DEPENDS NodeJS ${tests_qtjsruntimetest} qtjsruntime
 	)
 endif (QT4_FOUND)
 


### PR DESCRIPTION
This costs a bit of time, but avoid stale jsfileslist.txt files.
