### PR TITLE
Allow selection of empty lists by making editinfo elements inline blocks

### DIFF
--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -318,6 +318,12 @@ cursor|cursor[cursor|composing="true"] > .caret {
     top: auto !important;
 }
 
+editinfo|editinfo {
+    /* Empty or invisible display:inline elements respond very badly to mouse selection.
+       Inline blocks are much more reliably selectable in Chrome & friends */
+    display: inline-block;
+}
+
 .editInfoMarker {
     position: absolute;
     width: 10px;


### PR DESCRIPTION
Elements that are simply display:inline, but have no visible content can do strange things to the browser selections in Chrome. They will actually stop other preceding nodes in the same container from being selectable, instead causing the selection to climb to the parent container.

Fixes issue #30
