### PR TITLE
Restore focus after an undo or redo operation

### DIFF
--- a/webodf/lib/gui/CaretManager.js
+++ b/webodf/lib/gui/CaretManager.js
@@ -196,8 +196,6 @@ gui.CaretManager = function CaretManager(sessionController) {
 
             // wire up the cursor update to caret visibility update
             cursor.subscribe(ops.OdtCursor.signalCursorUpdated, scheduleCaretVisibilityCheck);
-            // Pass event focus to the session controller
-            sessionController.getEventManager().focus();
         } else {
             cursor.subscribe(ops.OdtCursor.signalCursorUpdated, caret.handleUpdate);
         }

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -658,6 +658,8 @@
             var op = new ops.OpAddCursor();
             op.init({memberid: inputMemberId});
             session.enqueue([op]);
+            // Immediately capture focus when the local cursor is inserted
+            eventManager.focus();
         }
         this.insertLocalCursor = insertLocalCursor;
 


### PR DESCRIPTION
Recent changes introduced in 26a9252 caused the focus to no longer be correctly restored after replacing the document root.

Additionally, don't re-capture focus when the cursor is re-added to the document. Performing the focus capture when a cursor is registered to the document causes undo/redo to slow down, as the focus gets pulled into the cursor as soon as the AddCursor op is executed. The focus should not be changed while executing operations.

Fixes issue #397
