### PR TITLE
Properly ignore inline roots in OdfUtils.getTextElements

### DIFF
--- a/webodf/lib/odf/OdfUtils.js
+++ b/webodf/lib/odf/OdfUtils.js
@@ -781,7 +781,7 @@ odf.OdfUtils = function OdfUtils() {
         function nodeFilter(node) {
             var result = NodeFilter.FILTER_REJECT;
             // do not return anything inside an character element or an inline root such as an annotation
-            if (isCharacterElement(node.parentNode) || isInlineRoot(node.parentNode)) {
+            if (isCharacterElement(node.parentNode) || isInlineRoot(node)) {
                 result = NodeFilter.FILTER_REJECT;
             } else if (node.nodeType === Node.TEXT_NODE) {
                 if (includeInsignificantWhitespace || isSignificantTextContent(/**@type{!Text}*/(node))) {

--- a/webodf/tests/odf/OdfUtilsTests.js
+++ b/webodf/tests/odf/OdfUtilsTests.js
@@ -249,9 +249,8 @@ odf.OdfUtilsTests = function OdfUtilsTests(runner) {
 
         t.textElements = t.odfUtils.getTextElements(t.range, false, false);
 
-        r.shouldBe(t, "t.textElements.length", "3");
+        r.shouldBe(t, "t.textElements.length", "2");
         r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[0]");
-        r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[1]");
         r.shouldBe(t, "t.textElements.shift()", "t.doc.childNodes[2]");
     }
     function getTextElements_InlineRoots_ExcludesCursorContent() {


### PR DESCRIPTION
Before it just ignored subelements of the inline root, so still adding the
root element to the result set (because isAnchoredAsCharacterElement(n) returned true for it)

Also fixes the related test which seemed to just match the outcome,
not was should expected, at least by the testname :)

Fixes #285 
Fixes #348 
Fixes #334
