### PR TITLE
Only set text eol=lf for certain files, not all (and do in /, not webodf/)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Set default behaviour for some text-like files, in case users don't have core.autocrlf set.
+
+
+*.cmake  text eol=lf
+*.c  text eol=lf
+*.conf  text eol=lf
+*.cpp  text eol=lf
+*.css  text eol=lf
+*.h  text eol=lf
+*.html  text eol=lf
+*.in  text eol=lf
+*.java  text eol=lf
+*.js  text eol=lf
+*.json  text eol=lf
+*.md  text eol=lf
+*.py  text eol=lf
+*.qrc  text eol=lf
+*.rdf  text eol=lf
+*.rng  text eol=lf
+*.sh  text eol=lf
+*.txt  text eol=lf
+*.ui  text eol=lf
+*.xml  text eol=lf
+*.xsl  text eol=lf

--- a/webodf/.gitattributes
+++ b/webodf/.gitattributes
@@ -1,2 +1,0 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text eol=lf


### PR DESCRIPTION
Fixup for a7edf7baad09d98d22eb9a80f94da82bf066ccef
