### PR TITLE
Do not grab click events on the eventTrap.

### DIFF
--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -286,6 +286,7 @@ cursor|cursor > .handle:after {
     opacity: 0;
     color: rgba(255, 255, 255, 0); /* hide the blinking caret by setting the colour to fully transparent */
     overflow: hidden; /* The overflow visibility is used to hide and show characters being entered */
+    pointer-events: none;
 }
 
 /* within a cursor */


### PR DESCRIPTION
Fixes an issue where clicking on the middle of
the character to the right of the caret would
cause the cursor to move to the start or end
of the document.
