### PR TITLE
Unbreak display of IME text during composition

### DIFF
--- a/webodf/lib/gui/EventManager.js
+++ b/webodf/lib/gui/EventManager.js
@@ -282,7 +282,7 @@ gui.EventManager = function EventManager(odtDocument) {
 
     /**
      * Returns the event trap div
-     * @return {!Element}
+     * @return {!HTMLInputElement}
      */
     this.getEventTrap = function () {
         return eventTrap;

--- a/webodf/lib/gui/InputMethodEditor.js
+++ b/webodf/lib/gui/InputMethodEditor.js
@@ -262,7 +262,7 @@
          * @return {undefined}
          */
         function synchronizeCompositionText() {
-            compositionElement.textContent = eventTrap.textContent;
+            compositionElement.textContent = eventTrap.value;
         }
 
         /**


### PR DESCRIPTION
The text was not appearing when composing via the IME. It would not show in the document until after the composition was complete.
