### PR TITLE
Normalize zoom slider's position for the zoom range

### DIFF
--- a/programs/editor/widgets/zoomSlider.js
+++ b/programs/editor/widgets/zoomSlider.js
@@ -82,7 +82,7 @@ define("webodf/editor/widgets/zoomSlider", [
 
         function updateSlider(zoomLevel) {
             if (slider) {
-                slider.set('value', Math.log(zoomLevel) / Math.log(extremeZoomFactor));
+                slider.set('value', Math.log(zoomLevel) / Math.log(extremeZoomFactor), false);
             }
         }
 


### PR DESCRIPTION
With there being a linear mapping between the slider's position and the zoom level, the middle position of the zoom slider has always _not_ matched the zoom level of `1`.  This was not very easily perceivable with the old zoom range of 0.3 and 1.5 (only slightly off-center), but with the new zoom levels from `0.25` to `4` this effect is highly pronounced.

This PR makes more natural -- the middle corresponds to `1`, the leftmost to `0.25`, the rightmost to `4`.

Fixes #440.
