### PR TITLE
Remove unnecessary @param declaration from cancelAnimationFrame

### DIFF
--- a/webodf/lib/runtime.js
+++ b/webodf/lib/runtime.js
@@ -1617,7 +1617,6 @@ function RhinoRuntime() {
     };
     /*jslint emptyblock: true */
     /**
-     * @param {!number} requestId
      * @return {undefined}
      */
     this.cancelAnimationFrame = function () {


### PR DESCRIPTION
Fixes a build warning. Thanks @kossebau for reporting.
