### PR TITLE
Use ranges when applying a style to better handle DOM changes

### DIFF
--- a/webodf/lib/odf/TextStyleApplicator.js
+++ b/webodf/lib/odf/TextStyleApplicator.js
@@ -153,10 +153,10 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
     /**
      * Moves the specified node and all further siblings within the outer range into a new standalone container
      * @param {!CharacterData} startNode Node to start movement to new container
-     * @param {!{startContainer: Node, startOffset: !number, endContainer: Node, endOffset: !number}} limits style application bounds
+     * @param {!Range} range style application bounds
      * @return {!Element}  Returns the container node that is to be restyled
      */
-    function moveToNewSpan(startNode, limits) {
+    function moveToNewSpan(startNode, range) {
         var document = startNode.ownerDocument,
             originalContainer = /**@type{!Element}*/(startNode.parentNode),
             styledContainer,
@@ -168,6 +168,17 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
             /**@type{!Array.<!Node>}*/
             styledNodes = [];
 
+        // Starting at the startNode, iterate forward until leaving the affected range
+        styledNodes.push(startNode);
+        node = startNode.nextSibling;
+        // Need to fetch all nodes to move before starting to move any, in case
+        // the range actually reference one of the nodes this loop is about to relocate
+        while (node && domUtils.rangeContainsNode(range, node)) {
+            loopGuard.check();
+            styledNodes.push(node);
+            node = node.nextSibling;
+        }
+
         // Do we need a new style container?
         if (!isTextSpan(originalContainer)) {
             // Yes, text node has no wrapping span
@@ -175,7 +186,7 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
             originalContainer.insertBefore(styledContainer, startNode);
             moveTrailing = false;
         } else if (startNode.previousSibling
-                && !domUtils.rangeContainsNode(limits, /**@type{!Element}*/(originalContainer.firstChild))) {
+                && !domUtils.rangeContainsNode(range, /**@type{!Element}*/(originalContainer.firstChild))) {
             // Yes, text node has prior siblings that are not styled
             // TODO what elements should be stripped when the clone occurs?
             styledContainer = originalContainer.cloneNode(false);
@@ -187,16 +198,6 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
             moveTrailing = true;
         }
 
-        // Starting at the startNode, iterate forward until leaving the affected range
-        styledNodes.push(startNode);
-        node = startNode.nextSibling;
-        // Need to fetch all nodes to move before starting to move any, in case
-        // the limits actually reference one of the nodes this loop is about to relocate
-        while (node && domUtils.rangeContainsNode(limits, node)) {
-            loopGuard.check();
-            styledNodes.push(node);
-            node = node.nextSibling;
-        }
         styledNodes.forEach(function (n) {
             if (n.parentNode !== styledContainer) {
                 styledContainer.appendChild(n);
@@ -225,11 +226,11 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
     /**
      * Apply the specified text style to the given text nodes
      * @param {!Array.<!CharacterData>} textNodes
-     * @param {!{startContainer: Node, startOffset: !number, endContainer: Node, endOffset: !number}} limits style application bounds
+     * @param {!Range} range style application bounds
      * @param {!Object} info Style information. Only data within "style:text-properties" will be considered and applied
      * @return {undefined}
      */
-    this.applyStyle = function (textNodes, limits, info) {
+    this.applyStyle = function (textNodes, range, info) {
         var textPropsOnly = {},
             isStyled,
             container,
@@ -248,7 +249,7 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
         function apply(n) {
             isStyled = styleLookup.isStyleApplied(n);
             if (isStyled === false) {
-                container = moveToNewSpan(n, limits);
+                container = moveToNewSpan(n, range);
                 styleCache.applyStyleToContainer(container);
             }
         }

--- a/webodf/lib/ops/OpApplyDirectStyling.js
+++ b/webodf/lib/ops/OpApplyDirectStyling.js
@@ -81,23 +81,14 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
             odfContainer = odfCanvas.odfContainer(),
             nextTextNodes = domUtils.splitBoundaries(range),
             textNodes = odfUtils.getTextNodes(range, false),
-            limits,
             textStyles;
-
-        // Avoid using the passed in range as boundaries move in strange ways as the DOM is modified
-        limits = {
-            startContainer: range.startContainer,
-            startOffset: range.startOffset,
-            endContainer: range.endContainer,
-            endOffset: range.endOffset
-        };
 
         textStyles = new odf.TextStyleApplicator(
             new odf.ObjectNameGenerator(/**@type{!odf.OdfContainer}*/(odfContainer), memberid), // TODO: use the instance in SessionController
             odtDocument.getFormatting(),
             odfContainer.rootElement.automaticStyles
         );
-        textStyles.applyStyle(textNodes, limits, info);
+        textStyles.applyStyle(textNodes, range, info);
         nextTextNodes.forEach(domUtils.normalizeTextNodes);
     }
 

--- a/webodf/tests/odf/TextStyleApplicatorTests.js
+++ b/webodf/tests/odf/TextStyleApplicatorTests.js
@@ -140,8 +140,7 @@ odf.TextStyleApplicatorTests = function TextStyleApplicatorTests(runner) {
      * @retur {undefined}
      */
     function applyStyle(range, info) {
-        var limits,
-            newTextNodes = domUtils.splitBoundaries(t.range),
+        var newTextNodes = domUtils.splitBoundaries(t.range),
             textNodes = odfUtils.getTextNodes(range, false),
             textStyles = new odf.TextStyleApplicator(
                 new odf.ObjectNameGenerator(/**@type{!odf.OdfContainer}*/(t.container), "tStyle"), // TODO: use the instance in SessionController
@@ -149,15 +148,7 @@ odf.TextStyleApplicatorTests = function TextStyleApplicatorTests(runner) {
                 t.container.rootElement.automaticStyles
             );
 
-        // Avoid using the passed in range as boundaries move in strange ways as the DOM is modified
-        limits = {
-            startContainer: range.startContainer,
-            startOffset: range.startOffset,
-            endContainer: range.endContainer,
-            endOffset: range.endOffset
-        };
-
-        textStyles.applyStyle(textNodes, limits, info);
+        textStyles.applyStyle(textNodes, range, info);
         newTextNodes.forEach(domUtils.normalizeTextNodes);
     }
     function apply_ContainerInsertion_SimpleTextRange() {

--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -1675,7 +1675,7 @@
    <office:text><text:p>AH</text:p></office:text>.
   </after>
  </test>
- <test name="ApplyStyle_CopesWithSelectionSpanningDifferentSubtrees" isFailing="true">
+ <test name="ApplyStyle_CopesWithSelectionSpanningDifferentSubtrees">
   <before><office:text><text:p><text:span>AB</text:span>C<text:s> </text:s><text:s> </text:s>D<text:s> </text:s>E<text:s> </text:s></text:p></office:text></before>
   <ops>
    <op optype="AddCursor" memberid="Joe"/>


### PR DESCRIPTION
When first created, the text style applicator used to move nodes around within the first while loop, often modifying the limiting range in ways that were not expected.

In 5a86bdd, this behaviour was re-written to gather all the relevant nodes and migrate them once all siblings in the container were checked. With this change, it is now best to use the range once again, as this avoids additional problems (see the modified test) with new children being added within the range if new styling containers are inserted.
