### PR TITLE
Fix blocky selections on iOS Safari

### DIFF
--- a/webodf/lib/core/DomUtils.js
+++ b/webodf/lib/core/DomUtils.js
@@ -649,7 +649,9 @@
                             left: rect.left + body.scrollLeft,
                             right: rect.right + body.scrollLeft,
                             top: rect.top + body.scrollTop,
-                            bottom: rect.bottom + body.scrollTop
+                            bottom: rect.bottom + body.scrollTop,
+                            width: rect.width,
+                            height: rect.height
                         });
                     }
                     return rect;


### PR DESCRIPTION
In `domUtils.getBoundingClientRect`, for the iOS quirk `elementBCRIgnoresBodyScroll`, the returned rect did not have `width` and `height` properties.

This caused the `grownRect` inside `SvgSelectionView.getFillerRect()` to be undefined, because it depended on the 'grower' rects to have nonzero widths and heights.
