### PR TITLE
Let the Editor create its divs itself

### DIFF
--- a/programs/editor/MemberListView.js
+++ b/programs/editor/MemberListView.js
@@ -98,8 +98,8 @@ define("webodf/editor/MemberListView",
                 imageElement = doc.createElement("img"),
                 fullnameNode = doc.createElement("div");
 
-            avatarDiv.className = "memberListButton";
-            fullnameNode.className = "memberListLabel";
+            avatarDiv.className = "webodfeditor-memberListButton";
+            fullnameNode.className = "webodfeditor-memberListLabel";
             avatarDiv.appendChild(imageElement);
             avatarDiv.appendChild(fullnameNode);
             avatarDiv.memberId = memberId; // TODO: namespace?

--- a/programs/editor/Tools.js
+++ b/programs/editor/Tools.js
@@ -57,7 +57,7 @@ define("webodf/editor/Tools", [
     function (ready, MenuItem, DropDownMenu, Button, DropDownButton, Toolbar, ParagraphAlignment, SimpleStyles, UndoRedoMenu, CurrentStyle, AnnotationControl, EditHyperlinks, ImageInserter, ParagraphStylesDialog, ZoomSlider, EditorSession) {
         "use strict";
 
-        return function Tools(args) {
+        return function Tools(toolbarElementId, args) {
             var tr = runtime.tr,
                 onToolDone = args.onToolDone,
                 loadOdtFile = args.loadOdtFile,
@@ -121,7 +121,7 @@ define("webodf/editor/Tools", [
 
             // init
             ready(function () {
-                toolbar = new Toolbar({}, "toolbar");
+                toolbar = new Toolbar({}, toolbarElementId);
 
                 // Undo/Redo
                 if (args.undoRedoEnabled) {

--- a/programs/editor/collabeditor.html
+++ b/programs/editor/collabeditor.html
@@ -67,19 +67,6 @@
 
     <!-- Editor page: start -->
     <div id="mainContainer" style="display: none;">
-      <div id="editor">
-        <span id="toolbar"></span>
-        <div id="container">
-          <div id="canvas"></div>
-        </div>
-      </div>
-      <div id="collaboration">
-        <div id="collabContainer">
-          <div id="members">
-            <div id="memberList"></div>
-          </div>
-        </div>
-      </div>
     </div>
     <!-- Editor page: end -->
   </body>

--- a/programs/editor/collabeditor.js
+++ b/programs/editor/collabeditor.js
@@ -69,19 +69,18 @@ var webodfEditor = (function () {
         booting = false;
 
     // TODO: just some quick hack done for testing, make nice (e.g. the position calculation is fragile)
-    function addStatusOverlay(parentElementId, symbolFileName, position) {
+    function addStatusOverlay(parentElement, symbolFileName, position) {
         var htmlns = document.documentElement.namespaceURI,
-            parentElement = document.getElementById(parentElementId),
             imageElement, overlay;
 
-        runtime.assert(parentElement, "heya, no such element with id "+parentElementId);
+        runtime.assert(parentElement, "heya, no such parentelement");
 
         overlay = document.createElementNS(htmlns, "div");
         imageElement = document.createElementNS(htmlns, "img");
         imageElement.src = symbolFileName;
         overlay.appendChild(imageElement);
-        overlay.style.position = "relative";
-        overlay.style.top = 24*position + "px";
+        overlay.style.position = "absolute";
+        overlay.style.top =  24*position + "px";
         overlay.style.opacity = "0.8";
         overlay.style.display = "none";
         parentElement.appendChild(overlay);
@@ -183,16 +182,20 @@ var webodfEditor = (function () {
                     function (Translator, Editor) {
                         var locale = navigator.language || "en-US",
                             t = new Translator(locale, function (editorTranslator) {
+                                var canvasContainerElement;
+
                                 runtime.setTranslator(editorTranslator.translate);
-                                savingOverlay = addStatusOverlay("editor", "document-save.png", 0);
-                                hasLocalUnsyncedOpsOverlay = addStatusOverlay("editor", "vcs-locally-modified.png", 0);
-                                disconnectedOverlay = addStatusOverlay("editor", "network-disconnect.png", 1);
 
                                 editorOptions = editorOptions || {}; // TODO: cleanup
                                 editorOptions.networkSecurityToken = token;
                                 editorOptions.closeCallback = closeEditing;
 
-                                editorInstance = new Editor(editorOptions, server, serverFactory);
+                                editorInstance = new Editor("mainContainer", editorOptions, server, serverFactory);
+                                canvasContainerElement = editorInstance.getCanvasContainerElement();
+                                savingOverlay = addStatusOverlay(canvasContainerElement, "document-save.png", 0);
+                                hasLocalUnsyncedOpsOverlay = addStatusOverlay(canvasContainerElement, "vcs-locally-modified.png", 0);
+                                disconnectedOverlay = addStatusOverlay(canvasContainerElement, "network-disconnect.png", 1);
+
                                 editorInstance.addEventListener(Editor.EVENT_BEFORESAVETOFILE, function() {
                                     savingOverlay.style.display = "";
                                 });

--- a/programs/editor/editor.css
+++ b/programs/editor/editor.css
@@ -7,15 +7,11 @@ html, body, #mainContainer {
     padding: 0px;
 }
 
-#mainContainer {
-    background-color: gray;
-}
-
-#editor *:focus {
+.webodfeditor-editor *:focus {
     outline: none;
 }
 
-#editor {
+.webodfeditor-editor {
     border: none;
     box-shadow: 0px 0px 14px #555;
     overflow: hidden;
@@ -23,7 +19,7 @@ html, body, #mainContainer {
     z-index: 4;
 }
 
-#toolbar {
+.webodfeditor-toolbarcontainer {
     top: 0;
     left: 0;
     right: 0;
@@ -32,7 +28,7 @@ html, body, #mainContainer {
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.25);
 }
 
-#container {
+.webodfeditor-canvascontainer {
     text-align: center;
     background-color: #ddd;
     overflow: auto;
@@ -43,7 +39,7 @@ html, body, #mainContainer {
     right: 0;
 }
 
-#canvas {
+.webodfeditor-canvas {
     margin-top: 30px;
     margin-left: 10px;
     margin-right: 10px;
@@ -61,52 +57,20 @@ html, body, #mainContainer {
  * of the slider and not have to be updated
  * every time a gesture ends
  */
-#canvas > div {
+.webodfeditor-canvas > div {
     box-shadow: 0px 0px 20px #aaa;
     border: 1px solid #ccc;
 }
 
-#collaboration {
-    width: 20%;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-
-    box-shadow: 0 0 3px #888;
-
-    border: none;
+.webodfeditor-members {
+    width: 70px !important;
+    padding: 2px !important;
+    text-align: center !important;
+    background-color: gray !important;
+    border: none !important;
 }
 
-#collaboration > .dojoxExpandoTitle {
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-    border: none;
-    background-color: rgb(243, 243, 243);
-}
-
-#collaboration > .dojoxExpandoWrapper {
-    width: 100%;
-    background-color: rgb(243, 243, 243);
-    border: 1px solid #769DC0;
-    border: none;
-
-}
-
-#members {
-    width: 70px;  
-    padding: 2px;
-    text-align: center;
-    background-color: gray;
-    border: none;
-}
-
-#members > #nameInfo {
-    padding-top: 3px;
-    padding-bottom: 3px;
-    width: 100%;
-    background-color: #eef;
-}
-
-#memberList .memberListButton {
+.webodfeditor-memberList .webodfeditor-memberListButton {
     margin-top: 5px;
     padding-top: 3px;
     margin-left: auto;
@@ -120,7 +84,7 @@ html, body, #mainContainer {
     cursor: pointer;
 }
 
-#memberList .memberListLabel {
+.webodfeditor-memberList .webodfeditor-memberListLabel {
     color: white;
     border-radius: 5px;
     padding: 2px;
@@ -128,11 +92,11 @@ html, body, #mainContainer {
     word-wrap: break-word;
     text-align: center justify;
 }
-div.memberListLabel[fullname]:before {
+div.webodfeditor-memberListLabel[fullname]:before {
     content: attr(fullname) "";
 }
 
-#memberList img {
+.webodfeditor-memberList img {
     box-shadow: 0px 0px 5px rgb(90, 90, 90) inset;
     background-color: rgb(200, 200, 200);
     border-radius: 5px;
@@ -143,7 +107,7 @@ div.memberListLabel[fullname]:before {
     margin: auto;
 }
 
-#memberList img:hover {
+.webodfeditor-memberList img:hover {
     opacity: 0.9;
 }
 

--- a/programs/editor/localeditor.html
+++ b/programs/editor/localeditor.html
@@ -46,12 +46,6 @@
 
   <body onload="webodfEditor.boot();" class="claro">
     <div id="mainContainer">
-      <div id="editor">
-        <span id="toolbar"></span>
-        <div id="container">
-          <div id="canvas"></div>
-        </div>
-      </div>
     </div>
   </body>
 </html>

--- a/programs/editor/localeditor.js
+++ b/programs/editor/localeditor.js
@@ -210,7 +210,7 @@ var webodfEditor = (function () {
                 var locale = navigator.language || "en-US",
                     t = new Translator(locale, function (editorTranslator) {
                         runtime.setTranslator(editorTranslator.translate);
-                        editorInstance = new Editor(editorOptions);
+                        editorInstance = new Editor("mainContainer", editorOptions);
                         editorInstance.openDocument(args.docUrl, localMemberId, startEditing);
                     });
             }

--- a/programs/editor/src-collabeditor.html
+++ b/programs/editor/src-collabeditor.html
@@ -68,19 +68,6 @@
 
     <!-- Editor page: start -->
     <div id="mainContainer" style="display: none;">
-      <div id="editor">
-        <span id="toolbar"></span>
-        <div id="container">
-          <div id="canvas"></div>
-        </div>
-      </div>
-      <div id="collaboration">
-        <div id="collabContainer">
-          <div id="members">
-            <div id="memberList"></div>
-          </div>
-        </div>
-      </div>
     </div>
     <!-- Editor page: end -->
   </body>

--- a/programs/editor/src-localeditor.html
+++ b/programs/editor/src-localeditor.html
@@ -47,12 +47,6 @@
 
   <body onload="webodfEditor.boot();" class="claro">
     <div id="mainContainer">
-      <div id="editor">
-        <span id="toolbar"></span>
-        <div id="container">
-          <div id="canvas"></div>
-        </div>
-      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Looking around I found that usually the id of an existing element is passed in, to have the whatever-to-be-created thing then extend that node with subelements as needed. This seems sane, as the caller of the API should not need to know what substructure is used, that is an implementation detail which can be safely hidden away (also allows to change things as needed, without breaking programs.
For current integration needs with ownCloud Documents the constructor of the Editor class accepts an optional parameter `toolbarContainerElementId`, to refer to an existing div element in a custom structure to be used to place the toolbar in, instead of creating one internally.

This PR also switches the styling of the editor substructures from ids to classnames, to remove another blocker for multiple editor instances in the same address space.

Next step will be splitting the Editor class into a version for single user editing and one version for collaborative session-based ones, because supporting both in one class only complicates things. See the branch https://github.com/kossebau/WebODF/tree/woeditor for a draft of the long-term goal.
