### PR TITLE
Viewer: Add fullscreen and presentation support for IE11.

### DIFF
--- a/programs/viewer/viewer.js
+++ b/programs/viewer/viewer.js
@@ -471,6 +471,7 @@ function Viewer(viewerPlugin) {
 
             if (!(document.cancelFullScreen || document.mozCancelFullScreen || document.webkitCancelFullScreen || document.msExitFullscreen)) {
                 document.getElementById('fullscreen').style.visibility = 'hidden';
+                document.getElementById('presentation').style.visibility = 'hidden';
             }
 
             document.getElementById('overlayCloseButton').addEventListener('click', self.toggleFullScreen);


### PR DESCRIPTION
This amazing browser does camelCasing differently for event names and also does not support the
`isFullscreen` or `msIsFullscreen` property on document.

Therefore this commit keeps track of the fullscreen state with a custom flag, instead of asking the browser
for it.
