### PR TITLE
Don't crash if the requested range is outside the any document root

### DIFF
--- a/webodf/lib/gui/SelectionController.js
+++ b/webodf/lib/gui/SelectionController.js
@@ -324,6 +324,10 @@ gui.SelectionController = function SelectionController(session, inputMemberId) {
         } else {
             anchorRoot = odtDocument.getRootElement(/**@type{!Node}*/(range.endContainer));
         }
+        if (!anchorRoot) {
+            // If the range end is not within a root element, use the document root instead
+            anchorRoot = odtDocument.getRootNode();
+        }
         filters.push(odtDocument.createRootFilter(anchorRoot));
         roundToClosestStep(anchorRoot, filters, range, true);
         roundToClosestStep(anchorRoot, filters, range, false);

--- a/webodf/tests/gui/SelectionControllerTests.js
+++ b/webodf/tests/gui/SelectionControllerTests.js
@@ -391,6 +391,20 @@ gui.SelectionControllerTests = function SelectionControllerTests(runner) {
         r.shouldBe(t, "t.position.length", "-2");
     }
 
+    function selectRange_SelectionOutsideRoot_ContainsToDocumentRoot() {
+        var doc = createOdtDocument("<text:p>ab</text:p>"),
+            range = testarea.ownerDocument.createRange();
+
+        range.setStart(doc, 0);
+        range.setEnd(doc, doc.childNodes.length);
+
+        t.selectionController.selectRange(range, true);
+
+        t.position = getCursorPosition();
+        r.shouldBe(t, "t.position.position", "0");
+        r.shouldBe(t, "t.position.length", "2");
+    }
+
     function expandToWordBoundaries_CollapsedInWord() {
         var doc = createOdtDocument("<text:p>one two three</text:p>"),
             p = doc.getElementsByTagNameNS(textns, "p")[0],
@@ -543,6 +557,7 @@ gui.SelectionControllerTests = function SelectionControllerTests(runner) {
 
             selectRange_BridgesMultipleRoots_IsConstrainedWithinAnchorRoot,
             selectRange_BridgesMultipleRoots_IsConstrainedWithinAnchorRoot_Reverse,
+            selectRange_SelectionOutsideRoot_ContainsToDocumentRoot,
 
             expandToWordBoundaries_CollapsedInWord,
             expandToWordBoundaries_CollasedAtWordStart,


### PR DESCRIPTION
Fixes a crash when running the benchmark.
