### PR TITLE
Only save user-modified style properties

### DIFF
--- a/programs/editor/widgets/paragraphStylesDialog.js
+++ b/programs/editor/widgets/paragraphStylesDialog.js
@@ -132,7 +132,7 @@ define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
                 * based on the mapping defined in propertyMapping.
                 * @param {!Object} properties
                 * @param {!Array.<!{propertyName:string,attributeName:string,unit:string}>} propertyMapping
-                * @return {undefined}
+                * @return {!Object}
                 */
                 function mappedProperties(properties, propertyMapping) {
                     var i, m, value,


### PR DESCRIPTION
This caches the values of both dialog panes when a style is opened in them, and generates style property objects containing only the modified properties using the new `updatedProperties` function upon calling `accept()`.
