### PR TITLE
Fix docnosis by loading also class xmldom.RelaxNGParser

### DIFF
--- a/programs/docnosis/docnosis.js
+++ b/programs/docnosis/docnosis.js
@@ -39,6 +39,7 @@
 runtime.loadClass("core.Zip");
 runtime.loadClass("core.Base64");
 runtime.loadClass("xmldom.RelaxNG");
+runtime.loadClass("xmldom.RelaxNGParser");
 
 /** This code runs a number of tests on an ODF document.
  * Ideally, it would use ODFContainer, but for now, it uses a custome container


### PR DESCRIPTION
Not sure why it is needed, didn't runtime now load already the complete classes in the manifest file, once one class is loaded?

Can just tell that this fixes things for me.
