### PR TITLE
Keep number of cursor positions in a document identical regardless of annotation display

### DIFF
--- a/webodf/lib/ops/TextPositionFilter.js
+++ b/webodf/lib/ops/TextPositionFilter.js
@@ -62,8 +62,10 @@ ops.TextPositionFilter = function TextPositionFilter(getRootNode) {
         var r, firstPos, rightOfChar;
         // accept if there is a character immediately to the left
         if (leftNode) {
-            // Disallow positions to the right of an inline root (like an annotation) andto the left of a grouping element (like an annotaiton highlight span)
             if (odfUtils.isInlineRoot(leftNode) && odfUtils.isGroupingElement(rightNode)) {
+                // Move first position after inline root inside trailing grouping element (part 1)
+                // Disallow positions to the right of an inline root (like an annotation) and
+                // to the left of a grouping element (like an annotation highlight span)
                 return FILTER_REJECT;
             }
             r = odfUtils.lookLeftForCharacter(leftNode);
@@ -73,6 +75,14 @@ ops.TextPositionFilter = function TextPositionFilter(getRootNode) {
             if (r === 2 && (odfUtils.scanRightForAnyCharacter(rightNode)
                 || odfUtils.scanRightForAnyCharacter(odfUtils.nextNode(container)))) {
                 // significant whitespace is ok, if not in trailing whitesp
+                return FILTER_ACCEPT;
+            }
+        } else {
+            // Note, cant use OdfUtils.previousNode here as that function automatically dives to the previous
+            // elements first child (if it has one)
+            if (odfUtils.isInlineRoot(container.previousSibling) && odfUtils.isGroupingElement(container)) {
+                // Move first position after inline root inside trailing grouping element (part 2)
+                // Allow the first position inside the first grouping element trailing an annotation
                 return FILTER_ACCEPT;
             }
         }

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -52,7 +52,8 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             office: odf.Namespaces.namespaceMap.office,
             draw: odf.Namespaces.namespaceMap.draw,
             e: "urn:webodf:names:editinfo",
-            c: "urn:webodf:names:cursor"
+            c: "urn:webodf:names:cursor",
+            html: "http://www.w3.org/1999/xhtml"
         };
 
     /**
@@ -68,7 +69,9 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
          * @return {!number}
          */
         this.acceptNode = function (node) {
-            if (node.namespaceURI === prefixToNamespace.c || node.namespaceURI === prefixToNamespace.e) {
+            if (node.namespaceURI === prefixToNamespace.c ||
+                node.namespaceURI === prefixToNamespace.e ||
+                node.namespaceURI === prefixToNamespace.html) {
                 return NodeFilter.FILTER_ACCEPT;
             }
             return odfFilter.acceptNode(node);
@@ -553,9 +556,13 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
     }
     function testAvailablePositions_Annotations() {
         testCursorPositions('<text:p>|a|b|<office:annotation><text:list><text:list-item><text:p>|</text:p></text:list-item></text:list></office:annotation>|c|d|<office:annotation-end></office:annotation-end>1|2|</text:p>');
+        testCursorPositions('<text:p>|a|<office:annotation><text:list><text:list-item><text:p>|b|</text:p></text:list-item></text:list></office:annotation>|c|<office:annotation-end></office:annotation-end>1|2|</text:p>');
+        testCursorPositions('<text:p>|a|<office:annotation><text:list><text:list-item><text:p>|b|</text:p></text:list-item></text:list></office:annotation>|<office:annotation-end></office:annotation-end>1|2|</text:p>');
     }
     function testAvailablePositions_BetweenAnnotationAndSpan() {
-        testCursorPositions('<text:p>|a|b|<office:annotation><text:list><text:list-item><text:p>|</text:p></text:list-item></text:list></office:annotation><text:span>c|d|e|</text:span><office:annotation-end></office:annotation-end>1|2|</text:p>');
+        testCursorPositions('<text:p>|a|b|<office:annotation><text:list><text:list-item><text:p>|</text:p></text:list-item></text:list></office:annotation><text:span>|c|d|</text:span><office:annotation-end></office:annotation-end>1|2|</text:p>');
+        testCursorPositions('<text:p>|a|<html:div class="annotationWrapper"><office:annotation><text:list><text:list-item><text:p>|b|</text:p></text:list-item></text:list></office:annotation></html:div><html:span class="webodf-annotationHighlight">|c|</html:span><office:annotation-end></office:annotation-end>1|2|</text:p>');
+        testCursorPositions('<text:p>|a|<html:div class="annotationWrapper"><office:annotation><text:list><text:list-item><text:p>|b|</text:p></text:list-item></text:list></office:annotation></html:div><html:span class="webodf-annotationHighlight">|</html:span><office:annotation-end></office:annotation-end>1|2|</text:p>');
     }
 
 


### PR DESCRIPTION
Rendering annotations causes the number of available cursor positions to be reduced by one. The original rule was added to stop the cursor getting in between the annotation highlight span and the annotation end. Rather than moving the valid cursor position to inside the span, this
simply removed the position entirely.

This patch adds additional logic to allow the cursor to stop just inside the annotation's highlight span so the number of positions in the doc stays consistent regardless of whether annotations are shown or not.

Incidentally, this also fixes issue #51.
