### PR TITLE
Slide toolbars in/out on tap

### DIFF
--- a/programs/viewer/viewer.css
+++ b/programs/viewer/viewer.css
@@ -3,8 +3,9 @@
     margin: 0;
 }
 
-body {
+html > body {
   font-family: sans-serif;
+  overflow: hidden;
 }
 
 .titlebar > span,
@@ -687,20 +688,46 @@ html[dir='rtl'] .dropdownToolbarButton {
     opacity: 0.5;
 }
 
-@media only screen and (max-width: 600px) and (max-height: 1000px) {
+@media only screen and (max-device-width: 800px) and (max-device-height: 800px) {
     #canvasContainer {
         top: 0;
         bottom: 0;
     }
+
+    #overlayNavigator {
+        height: 100px;
+        pointer-events: none;
+    }
+    #nextPage, #previousPage {
+        pointer-events: all;
+    }
+
     #titlebar, #toolbarContainer {
         background-color: rgba(0, 0, 0, 0.6);
         background-image: none;
+        -webkit-transition: all 0.5s;
+        -moz-transition: all 0.5s;
+        transition: all 0.5s;
     }
-    #overlayNavigator.touched {
+
+    #titlebar {
+        top: -32px;
+    }
+    #titlebar.viewer-touched {
+        top: 0px;
+    }
+    #toolbarContainer {
+        bottom: -32px;
+    }
+    #toolbarContainer.viewer-touched {
+        bottom: 0px;
+    }
+
+    .viewer-touched {
         display: block;
-        opacity: 1;
-        height: 100px;
+        opacity: 1 !important;
     }
+
     #next, #previous {
         display: none;
     }

--- a/programs/viewer/viewer.js
+++ b/programs/viewer/viewer.js
@@ -55,6 +55,8 @@ function Viewer(viewerPlugin) {
         viewerElement = document.getElementById('viewer'),
         canvasContainer = document.getElementById('canvasContainer'),
         overlayNavigator = document.getElementById('overlayNavigator'),
+        titlebar = document.getElementById('titlebar'),
+        toolbar = document.getElementById('toolbarContainer'),
         pageSwitcher = document.getElementById('toolbarLeft'),
         zoomWidget = document.getElementById('toolbarMiddleContainer'),
         scaleSelector = document.getElementById('scaleSelect'),
@@ -65,7 +67,10 @@ function Viewer(viewerPlugin) {
         pages = [],
         currentPage,
         scaleChangeTimer,
-        touchTimer;
+        touchTimer,
+        toolbarTouchTimer,
+        /**@const*/
+        UI_FADE_DURATION = 5000;
 
     function initializeAboutInformation() {
         var basedOnDiv, aboutButton, pluginName, pluginVersion, pluginURL;
@@ -364,9 +369,7 @@ function Viewer(viewerPlugin) {
      * Presentation mode involves fullscreen + hidden UI controls
      */
     this.togglePresentationMode = function () {
-        var titlebar = document.getElementById('titlebar'),
-            toolbar = document.getElementById('toolbarContainer'),
-            overlayCloseButton = document.getElementById('overlayCloseButton');
+        var overlayCloseButton = document.getElementById('overlayCloseButton');
 
         if (!presentationMode) {
             titlebar.style.display = toolbar.style.display = 'none';
@@ -454,11 +457,36 @@ function Viewer(viewerPlugin) {
 
     function showOverlayNavigator() {
         if (isSlideshow) {
-            overlayNavigator.className = 'touched';
+            overlayNavigator.className = 'viewer-touched';
             window.clearTimeout(touchTimer);
             touchTimer = window.setTimeout(function () {
                 overlayNavigator.className = '';
-            }, 2000);
+            }, UI_FADE_DURATION);
+        }
+    }
+
+    /**
+     * @param {!boolean} timed Fade after a while
+     */
+    function showToolbars() {
+        titlebar.classList.add('viewer-touched');
+        toolbar.classList.add('viewer-touched');
+        window.clearTimeout(toolbarTouchTimer);
+        toolbarTouchTimer = window.setTimeout(function () {
+            hideToolbars();
+        }, UI_FADE_DURATION);
+    }
+
+    function hideToolbars() {
+        titlebar.classList.remove('viewer-touched');
+        toolbar.classList.remove('viewer-touched');
+    }
+
+    function toggleToolbars() {
+        if (titlebar.classList.contains('viewer-touched')) {
+            hideToolbars();
+        } else {
+            showToolbars();
         }
     }
 
@@ -526,6 +554,9 @@ function Viewer(viewerPlugin) {
 
             canvasContainer.addEventListener('click', showOverlayNavigator);
             overlayNavigator.addEventListener('click', showOverlayNavigator);
+            canvasContainer.addEventListener('click', toggleToolbars);
+            titlebar.addEventListener('click', showToolbars);
+            toolbar.addEventListener('click', showToolbars);
 
             window.addEventListener('scalechange', function (evt) {
                 var customScaleOption = document.getElementById('customScaleOption'),


### PR DESCRIPTION
The translucent overlay toolbars will now show only on a mobile device's browser with less than `800px` of width or height, so the viewer will look uniform for all iframe sizes on a regular desktop browser.
The toolbars will slide in/out on tapping, and slide out after 5 seconds if open.
