### PR TITLE
Adapt name of firefox extension build target and file to actual name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,8 +317,8 @@ macro(COPY_FILES _varname _srcdir _tgtdir)
 endmacro(COPY_FILES _directory _files)
 
 set (VIEWERBUILDDIR ${CMAKE_CURRENT_BINARY_DIR}/viewer)
-set(WEBODFXPIDIR ${CMAKE_CURRENT_BINARY_DIR}/webodf-${WEBODF_VERSION})
-set(WEBODFXPI ${WEBODFXPIDIR}.xpi)
+set(FIREFOX_EXTENSION_ODFVIEWER_DIR ${CMAKE_CURRENT_BINARY_DIR}/firefox-extension-odfviewer-${WEBODF_VERSION})
+set(FIREFOX_EXTENSION_ODFVIEWER ${FIREFOX_EXTENSION_ODFVIEWER_DIR}.xpi)
 
 add_subdirectory(webodf)
 add_subdirectory(programs)
@@ -341,7 +341,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/programs/benchmark ${WEBODFZIPDIR}/benchmark
 
     # firefox
-    COMMAND ${CMAKE_COMMAND} -E copy ${WEBODFXPI} ${WEBODFZIPDIR}
+    COMMAND ${CMAKE_COMMAND} -E copy ${FIREFOX_EXTENSION_ODFVIEWER} ${WEBODFZIPDIR}
 
     # zip using javascript code running in node.js
     COMMAND ${NODE} ARGS webodf/lib/runtime.js ${CMAKE_CURRENT_SOURCE_DIR}/webodf/tools/zipdir.js

--- a/programs/firefoxextension/CMakeLists.txt
+++ b/programs/firefoxextension/CMakeLists.txt
@@ -11,20 +11,20 @@ set (TOOLSDIR ${CMAKE_CURRENT_SOURCE_DIR}/../../webodf/tools)
 
 # write webodf.js into viewer.html
 add_custom_command(
-    OUTPUT ${WEBODFXPI}
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${WEBODFXPIDIR}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${WEBODFXPIDIR}/content/web
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/install.rdf ${WEBODFXPIDIR}
+    OUTPUT ${FIREFOX_EXTENSION_ODFVIEWER}
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${FIREFOX_EXTENSION_ODFVIEWER_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${FIREFOX_EXTENSION_ODFVIEWER_DIR}/content/web
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/install.rdf ${FIREFOX_EXTENSION_ODFVIEWER_DIR}
     COMMAND ${NODE} ARGS ${RUNTIME} ${TOOLSDIR}/replaceByFileContents.js
         ${CMAKE_CURRENT_SOURCE_DIR}/content/web/viewer.html.in
-        ${WEBODFXPIDIR}/content/web/viewer.html
+        ${FIREFOX_EXTENSION_ODFVIEWER_DIR}/content/web/viewer.html
         @WEBODF_JS@ ${CMAKE_BINARY_DIR}/webodf/webodf.js
     COMMAND ${NODE} ARGS ../../webodf/lib/runtime.js packextension.js
-        ${WEBODFXPIDIR}
+        ${FIREFOX_EXTENSION_ODFVIEWER_DIR}
         ${FIREFOXEXTENSIONFILES}
     COMMAND ${NODE} ARGS ../../webodf/lib/runtime.js ${CMAKE_CURRENT_SOURCE_DIR}/../../webodf/tools/zipdir.js
-        ${WEBODFXPIDIR}
-        ${WEBODFXPI}
+        ${FIREFOX_EXTENSION_ODFVIEWER_DIR}
+        ${FIREFOX_EXTENSION_ODFVIEWER}
         notopdir
     DEPENDS NodeJS
          ${TOOLSDIR}/replaceByFileContents.js
@@ -36,4 +36,4 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_custom_target(firefoxextension-target DEPENDS ${WEBODFXPI})
+add_custom_target(firefoxextension-target DEPENDS ${FIREFOX_EXTENSION_ODFVIEWER})


### PR DESCRIPTION
webodf-0.4.2-2167-gacc4b06-dirty.xpi is less descriptive than firefox-extension-odfviewer-0.4.2-2167-gacc4b06-dirty.xpi, given it contains a Firefox extension named ODF Viewer, or?
