### PR TITLE
Only expand selection on multiple clicks with the primary mouse button

### DIFF
--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -668,6 +668,7 @@ gui.SessionControllerOptions = function () {
                     }
                 }
             }
+            // TODO assumes the mouseup/contextmenu is the same button as the mousedown that initialized the clickCount
             clickCount = 0;
             clickStartedWithinCanvas = false;
             isMouseMoved = false;


### PR DESCRIPTION
Chrome + WebKit increment the click count value for the MouseEvent even if the user switches buttons. E.g., a double click then right click will report the last event as {button: 2, detail: 3}, causing the
selection to expand to the paragraph bounds.

Now, the click count is only reported as non-zero if the current event is with the primary mouse button (left by default, or the right button if the user has switched their primary mouse button around).
