### PR TITLE
Make html files of editor and viewer HTML5 validated

### DIFF
--- a/programs/editor/collabeditor.html
+++ b/programs/editor/collabeditor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML>
 <html xml:lang="en" lang="en">
   <head>
     <!--
@@ -10,13 +10,13 @@
     sessions which are offered in a simple list and can be joined.
     This page is meant to be served out of a webodf build directory.
     -->
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"/>
 
     <title>Collaborative Editor</title>
 
     <!-- dojo setup: start -->
-    <script type="text/javascript" charset="utf-8">
+    <script type="text/javascript">
       var usedLocale = "C";
       if (navigator && navigator.language && navigator.language.match(/^(ru|de)/)) {
         usedLocale = navigator.language.substr(0,2);

--- a/programs/editor/localeditor.html
+++ b/programs/editor/localeditor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML>
 <html xml:lang="en" lang="en">
   <head>
     <!--
@@ -8,13 +8,13 @@
     happens client-side in your browser.
     This page is meant to be served out of a webodf build directory.
     -->
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"/>
 
     <title>Local Editor</title>
 
     <!-- dojo setup: start -->
-    <script type="text/javascript" charset="utf-8">
+    <script type="text/javascript">
         var usedLocale = "C";
         if (navigator && navigator.language && navigator.language.match(/^(ru|de)/)) {
             usedLocale = navigator.language.substr(0,2);

--- a/programs/editor/src-collabeditor.html
+++ b/programs/editor/src-collabeditor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML>
 <html xml:lang="en" lang="en">
   <head>
     <!--
@@ -9,13 +9,13 @@
     and requires pullbox functionality in the server.
     This page is meant to be served out of a webodf source directory.
     -->
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"/>
 
     <title>Collaborate Editor (CDN)</title>
 
     <!-- dojo setup: start -->
-    <script type="text/javascript" charset="utf-8">
+    <script type="text/javascript">
       var basedir = window.location.pathname;
       basedir = basedir.substr(0, basedir.lastIndexOf("/"));
       dojoConfig = {

--- a/programs/editor/src-localeditor.html
+++ b/programs/editor/src-localeditor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML>
 <html xml:lang="en" lang="en">
   <head>
     <!--
@@ -7,13 +7,13 @@
     but uses dojo directly from Google's CDN (content delivery networks).
     This page is meant to be served out of a webodf source directory.
     -->
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"/>
 
     <title>Local Editor (CDN)</title>
 
     <!-- dojo setup: start -->
-    <script type="text/javascript" charset="utf-8">
+    <script type="text/javascript">
       var basedir = window.location.pathname;
       basedir = basedir.substr(0, basedir.lastIndexOf("/"));
       dojoConfig = {

--- a/programs/viewer/index-amalgamation-template.html
+++ b/programs/viewer/index-amalgamation-template.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html dir="ltr" lang="en-US">
     <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>ViewerJS</title>
         <link rel="stylesheet" type="text/css" href="viewer.css" media="screen"/>
         <script type="text/javascript">
             ////<![CDATA[
@@ -27,7 +30,7 @@
                             <button id = "next" class = "toolbarButton pageDown" title = "Next Page"></button>
                         </div>
                         <label id = "pageNumberLabel" class = "toolbarLabel" for = "pageNumber">Page:</label>
-                        <input type = "number" id = "pageNumber" class = "toolbarField pageNumber"></input>
+                        <input type = "number" id = "pageNumber" class = "toolbarField pageNumber"/>
                         <span id = "numPages" class = "toolbarLabel"></span>
                     </div>
                     <div class = "outerCenter">
@@ -42,7 +45,7 @@
                                     <option id="pageAutoOption" value="auto" selected>Automatic</option>
                                     <option id="pageActualOption" value="page-actual">Actual Size</option>
                                     <option id="pageWidthOption" value="page-width">Full Width</option>
-                                    <option id="customScaleOption" value="custom"></option>
+                                    <option id="customScaleOption" value="custom"> </option>
                                     <option value="0.5">50%</option>
                                     <option value="0.75">75%</option>
                                     <option value="1">100%</option>

--- a/programs/viewer/index.html
+++ b/programs/viewer/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html dir="ltr" lang="en-US">
     <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>ViewerJS</title>
         <!-- If you want to use custom CSS (@font-face rules, for example) you should uncomment
              the following reference and use a local.css file for that. See the example.local.css
              file for a sample.
@@ -33,7 +36,7 @@
                             <button id = "next" class = "toolbarButton pageDown" title = "Next Page"></button>
                         </div>
                         <label id = "pageNumberLabel" class = "toolbarLabel" for = "pageNumber">Page:</label>
-                        <input type = "number" id = "pageNumber" class = "toolbarField pageNumber"></input>
+                        <input type = "number" id = "pageNumber" class = "toolbarField pageNumber"/>
                         <span id = "numPages" class = "toolbarLabel"></span>
                     </div>
                     <div id = "toolbarMiddleContainer" class = "outerCenter">
@@ -48,7 +51,7 @@
                                     <option id="pageAutoOption" value="auto" selected>Automatic</option>
                                     <option id="pageActualOption" value="page-actual">Actual Size</option>
                                     <option id="pageWidthOption" value="page-width">Full Width</option>
-                                    <option id="customScaleOption" value="custom"></option>
+                                    <option id="customScaleOption" value="custom"> </option>
                                     <option value="0.5">50%</option>
                                     <option value="0.75">75%</option>
                                     <option value="1">100%</option>


### PR DESCRIPTION
Check done with http://validator.w3.org/check

Open questions:
- Not sure what to put into `<title> </title>` for the viewer HTML files, any proposals? At least for validation the tag needs to be there and non-empty
- `<option id="customScaleOption" value="custom"> </option>` needs to have some non-empty content as well to be validated. Actual content is set by the code, but might be good to still have the original html validated. Any other sane default content there then one empty space?
