### PR TITLE
Fix crash when no style:list-level-properties is present

### DIFF
--- a/webodf/tests/odf/ListStyleToCssTests.js
+++ b/webodf/tests/odf/ListStyleToCssTests.js
@@ -130,6 +130,34 @@ odf.ListStyleToCssTests = function ListStyleToCssTests(runner) {
 
     }
 
+    function style_WithNo_list_level_poperties() {
+        applyListStyles(
+            '<text:list-style style:name="lijst">' +
+              '<text:list-level-style-bullet text:bullet-char="-" text:level="1">' +
+              '</text:list-level-style-bullet>' +
+            '</text:list-style>',
+            "");
+        r.shouldBe(t, "t.styleSheet.cssRules.length", "3");
+        r.shouldBe(t, "t.styleSheet.cssRules.rules[0].ruleText", "'text|list[text|style-name=\"lijst\"] > text|list-item{margin-left: 0px;}'");
+        r.shouldBe(t, "t.styleSheet.cssRules.rules[1].ruleText", "'text|list[text|style-name=\"lijst\"] > text|list-item > text|list{margin-left: 0px;}'");
+        r.shouldBe(t, "t.styleSheet.cssRules.rules[2].ruleText", "'text|list[text|style-name=\"lijst\"] > text|list-item > *:not(text|list):first-child:before{text-align: left;counter-increment:list;display: inline-block;min-width: 0px;margin-left: 0px;padding-right: 0px;\\ncontent: \"-\";\\n}'");
+    }
+
+    function style_list_level_properties_WithNo_style_list_level_label_alignment() {
+        applyListStyles(
+            '<text:list-style style:name="lijst">' +
+              '<text:list-level-style-bullet text:bullet-char="-" text:level="1">' +
+                '<style:list-level-properties text:list-level-position-and-space-mode="label-alignment">' +
+                '</style:list-level-properties>' +
+              '</text:list-level-style-bullet>' +
+            '</text:list-style>',
+            "");
+        r.shouldBe(t, "t.styleSheet.cssRules.length", "3");
+        r.shouldBe(t, "t.styleSheet.cssRules.rules[0].ruleText", "'text|list[text|style-name=\"lijst\"] > text|list-item{margin-left: 0px;}'");
+        r.shouldBe(t, "t.styleSheet.cssRules.rules[1].ruleText", "'text|list[text|style-name=\"lijst\"] > text|list-item > text|list{margin-left: 0px;}'");
+        r.shouldBe(t, "t.styleSheet.cssRules.rules[2].ruleText", "'text|list[text|style-name=\"lijst\"] > text|list-item > *:not(text|list):first-child:before{text-align: left;counter-increment:list;display: inline-block;margin-left: 0px;\\ncontent: \"-\";\\n}'");
+    }
+
     /**
      * WebKit, Chrome + FF all have radically different ways of joining & quoting CSS content.
      * The tests being created depend on a predictable string being parsed out for comparison, hence
@@ -357,7 +385,9 @@ odf.ListStyleToCssTests = function ListStyleToCssTests(runner) {
             style_list_level_label_alignment_WithNo_fo_margin_left,
             numberedListPrefixes,
             numberedListSuffixes,
-            bulletCharacters
+            bulletCharacters,
+            style_WithNo_list_level_poperties,
+            style_list_level_properties_WithNo_style_list_level_label_alignment
         ]);
     };
     this.asyncTests = function () {

--- a/webodf/tests/odf/layouttests.xml
+++ b/webodf/tests/odf/layouttests.xml
@@ -229,6 +229,87 @@
    </check>
   </layoutchecks>
  </test>
+
+ <test name="list-level-properties-missing">
+  <input>
+   <office:document-styles>
+    <office:automatic-styles>
+     <text:list-style style:name="L1">
+      <text:list-level-style-number style:num-format="1" style:num-suffix=")" text:level="1">
+      </text:list-level-style-number>
+      <text:list-level-style-number style:num-format="a" style:num-letter-sync="true" style:num-suffix=")" text:level="2">
+      </text:list-level-style-number>
+     </text:list-style>
+    </office:automatic-styles>
+   </office:document-styles>
+   <office:text>
+    <text:list text:style-name="L1" xml:id="list432847329805709832">
+     <text:list-item>
+      <text:p text:style-name="P1">This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test.</text:p>
+      <text:list>
+       <text:list-item>
+        <text:p text:style-name="P1">This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test.</text:p>
+       </text:list-item>
+      </text:list>
+     </text:list-item>
+    </text:list>
+   </office:text>
+  </input>
+  <layoutchecks>
+   <check xpath="(.//text:list)[1]">
+    <marginLeft value="0px"/>
+   </check>
+   <check xpath="(.//text:list)[2]">
+    <marginLeft value="0px"/>
+   </check>
+  </layoutchecks>
+ </test>
+
+ <test name="list-label-alignment-missing">
+  <input>
+   <office:document-styles>
+    <office:automatic-styles>
+     <text:list-style style:name="L1">
+      <text:list-level-style-number style:num-format="1" style:num-suffix="." text:level="1" text:style-name="Numbering_20_Symbols">
+       <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+       </style:list-level-properties>
+      </text:list-level-style-number>
+      <text:list-level-style-number style:num-format="1" style:num-suffix="." text:display-levels="2" text:level="2" text:style-name="Numbering_20_Symbols">
+       <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+       </style:list-level-properties>
+      </text:list-level-style-number>
+     </text:list-style>
+    </office:automatic-styles>
+   </office:document-styles>
+   <office:text>
+    <text:list text:style-name="L1" xml:id="list555894327569445">
+     <text:list-item>
+      <text:p text:style-name="P1">This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test.</text:p>
+      <text:list>
+       <text:list-item>
+        <text:p text:style-name="P1">This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test, This is a numbering test.</text:p>
+       </text:list-item>
+      </text:list>
+     </text:list-item>
+    </text:list>
+   </office:text>
+  </input>
+  <layoutchecks>
+   <check xpath="(.//text:list)[1]">
+    <marginLeft value="0px"/>
+   </check>
+   <check xpath="(.//text:list)[2]">
+    <marginLeft value="0px"/>
+   </check>
+   <check xpath="(.//text:list-item)[1]">
+    <marginLeft value="0px"/>
+   </check>
+   <check xpath="(.//text:list-item)[2]">
+    <marginLeft value="0px"/>
+   </check>
+  </layoutchecks>
+ </test>
+
  <test name="label-alignment-list">
   <input>
    <office:document-styles>


### PR DESCRIPTION
Just a little drive-by fix I did on noticing this frequent crash whilst testing ODPs for my `z-index` PR.

Previously, WebODF would simply not load documents which did not come with this optional element in a list style. Documents which contain list styles are potentially affected.

[This document](http://www.kde.org/kdeslides/fosdem2007/2007-02-flaviocastelli-strigi_desktop_integration.odp) is an example that crashes and fails to load; fixed by this PR.
