### PR TITLE
Use Error objects in callback passed to "destroy" methods

### DIFF
--- a/programs/editor/Editor.js
+++ b/programs/editor/Editor.js
@@ -203,7 +203,7 @@ define("webodf/editor/Editor", [
 
             /**
              * Closes a single-user document, and does cleanup.
-             * @param {!function(!Object=)} callback, passing an error object in case of error
+             * @param {!function(!Error=)} callback, passing an error object in case of error
              * @return undefined;
              */
             this.closeDocument = function (callback) {
@@ -323,7 +323,7 @@ define("webodf/editor/Editor", [
             /**
              * Closes the current editing running editing (polling-timer),
              * cleanup.
-             * @param {!function(!Object=)} callback, passing an error object in case of error
+             * @param {!function(!Error=)} callback, passing an error object in case of error
              * @return {undefined}
              */
             this.closeSession = function (callback) {
@@ -469,7 +469,7 @@ define("webodf/editor/Editor", [
             }
 
             /**
-             * @param {!function(!Object=)} callback, passing an error object in case of error
+             * @param {!function(!Error=)} callback, passing an error object in case of error
              * @return {undefined}
              */
             this.destroy = function (callback) {

--- a/programs/editor/EditorSession.js
+++ b/programs/editor/EditorSession.js
@@ -599,7 +599,7 @@ define("webodf/editor/EditorSession", [
         }
 
         /**
-         * @param {!function(!Object=)} callback passing an error object in case of error
+         * @param {!function(!Error=)} callback passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function(callback) {

--- a/programs/editor/MemberListView.js
+++ b/programs/editor/MemberListView.js
@@ -198,7 +198,7 @@ define("webodf/editor/MemberListView",
         };
 
         /**
-         * @param {!function(!Object=)} callback, passing an error object in case of error
+         * @param {!function(!Error=)} callback, passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function (callback) {

--- a/programs/editor/Tools.js
+++ b/programs/editor/Tools.js
@@ -100,7 +100,7 @@ define("webodf/editor/Tools", [
             this.setEditorSession = setEditorSession;
 
             /**
-             * @param {!function(!Object=)} callback, passing an error object in case of error
+             * @param {!function(!Error=)} callback, passing an error object in case of error
              * @return {undefined}
              */
             this.destroy = function (callback) {

--- a/webodf/lib/core/Async.js
+++ b/webodf/lib/core/Async.js
@@ -40,7 +40,7 @@
     "use strict";
 
     /**
-     * @return {!{forEach:!function(!Array.<*>,!function(*, !function(!string):undefined):undefined,!function(?string)):undefined, destroyAll:function(!Array.<!function(!function(!Object=))>,!function(!Object=)):undefined}}
+     * @return {!{forEach:!function(!Array.<*>,!function(*, !function(!string):undefined):undefined,!function(?string)):undefined, destroyAll:function(!Array.<!function(!function(!Error=))>,!function(!Error=)):undefined}}
      */
     function createASyncSingleton() {
         /**
@@ -76,14 +76,14 @@
         }
 
         /**
-         * @param {!Array.<!function(!function(!Object=))>} items
-         * @param {!function(!Object=)} callback
+         * @param {!Array.<!function(!function(!Error=))>} items
+         * @param {!function(!Error=)} callback
          * @return {undefined}
          */
         function destroyAll(items, callback) {
             /**
              * @param {!number} itemIndex
-             * @param {!Object|undefined} err
+             * @param {!Error|undefined} err
              * @return {undefined}
              */
             function destroy(itemIndex, err) {
@@ -109,7 +109,7 @@
     /**
      * Wrapper for Async functions
      * @const
-     * @type {!{forEach:!function(!Array.<*>,!function(*, !function(!string):undefined):undefined,!function(?string)):undefined, destroyAll:function(!Array.<!function(!function(!Object=))>,!function(!Object=)):undefined}}
+     * @type {!{forEach:!function(!Array.<*>,!function(*, !function(!string):undefined):undefined,!function(?string)):undefined, destroyAll:function(!Array.<!function(!function(!Error=))>,!function(!Error=)):undefined}}
      */
     core.Async = createASyncSingleton();
 }());

--- a/webodf/lib/core/Destroyable.js
+++ b/webodf/lib/core/Destroyable.js
@@ -49,7 +49,7 @@ core.Destroyable = function Destroyable() {
 /**
  * Destroy the object.
  * Do not access any member of this object after this call.
- * @param {function(!Object=):undefined} callback
+ * @param {function(!Error=):undefined} callback
  * @return {undefined}
  */
 core.Destroyable.prototype.destroy = function (callback) {"use strict"; };

--- a/webodf/lib/core/ScheduledTask.js
+++ b/webodf/lib/core/ScheduledTask.js
@@ -104,7 +104,7 @@ core.ScheduledTask = function ScheduledTask(fn, scheduleTask, cancelTask) {
 
     /**
      * Cancel any pending requests
-     * @param {!function(!Object=)} callback
+     * @param {!function(!Error=)} callback
      */
     this.destroy = function (callback) {
         cancel();

--- a/webodf/lib/gui/AnnotationController.js
+++ b/webodf/lib/gui/AnnotationController.js
@@ -183,7 +183,7 @@ gui.AnnotationController = function AnnotationController(session, inputMemberId)
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function(callback) {

--- a/webodf/lib/gui/Avatar.js
+++ b/webodf/lib/gui/Avatar.js
@@ -107,7 +107,7 @@ gui.Avatar = function Avatar(parentElement, avatarInitiallyVisible) {
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/Caret.js
+++ b/webodf/lib/gui/Caret.js
@@ -532,7 +532,7 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
     }
 
     /**
-     * @param {!function(!Object=)} callback Callback to call when the destroy is complete, passing an error object in case of error
+     * @param {!function(!Error=)} callback Callback to call when the destroy is complete, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/CaretManager.js
+++ b/webodf/lib/gui/CaretManager.js
@@ -217,7 +217,7 @@ gui.CaretManager = function CaretManager(sessionController) {
     this.getCarets = getCarets;
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/DirectFormattingController.js
+++ b/webodf/lib/gui/DirectFormattingController.js
@@ -760,7 +760,7 @@ gui.DirectFormattingController = function DirectFormattingController(session, in
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/EditInfoHandle.js
+++ b/webodf/lib/gui/EditInfoHandle.js
@@ -94,7 +94,7 @@ gui.EditInfoHandle = function EditInfoHandle(parentElement) {
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/EditInfoMarker.js
+++ b/webodf/lib/gui/EditInfoMarker.js
@@ -161,7 +161,7 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/EventManager.js
+++ b/webodf/lib/gui/EventManager.js
@@ -617,7 +617,7 @@ gui.EventManager = function EventManager(odtDocument) {
     };
 
     /**
-      * @param {!function(!Object=)} callback passing an error object in case of error
+      * @param {!function(!Error=)} callback passing an error object in case of error
       * @return {undefined}
       */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/HyperlinkClickHandler.js
+++ b/webodf/lib/gui/HyperlinkClickHandler.js
@@ -238,7 +238,7 @@ gui.HyperlinkClickHandler = function HyperlinkClickHandler(getContainer, keyDown
     /**
      * Destroy the object.
      * Do not access any member of this object after this call.
-     * @param {function(!Object=):undefined} callback
+     * @param {function(!Error=):undefined} callback
      * @return {undefined}
      */
     this.destroy = function(callback) {

--- a/webodf/lib/gui/HyperlinkTooltipView.js
+++ b/webodf/lib/gui/HyperlinkTooltipView.js
@@ -149,7 +149,7 @@ gui.HyperlinkTooltipView = function HyperlinkTooltipView(odfCanvas, getActiveMod
     /**
      * Destroy the object.
      * Do not access any member of this object after this call.
-     * @param {function(!Object=):undefined} callback
+     * @param {function(!Error=):undefined} callback
      * @return {undefined}
      */
     this.destroy = function(callback) {

--- a/webodf/lib/gui/IOSSafariSupport.js
+++ b/webodf/lib/gui/IOSSafariSupport.js
@@ -59,7 +59,7 @@ gui.IOSSafariSupport = function (eventManager) {
     }
 
     /**
-     * @param {!function(!Object=)} callback
+     * @param {!function(!Error=)} callback
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/gui/InputMethodEditor.js
+++ b/webodf/lib/gui/InputMethodEditor.js
@@ -88,7 +88,7 @@
         }
 
         /**
-         * @param {function()} callback
+         * @param {function(!Error=)} callback
          */
         this.destroy = function (callback) {
             eventManager.unsubscribe("textInput", clearSuppression);
@@ -270,7 +270,7 @@
         };
 
         /**
-         * @param {function()} callback
+         * @param {function(!Error=)} callback
          */
         this.destroy = function (callback) {
             eventManager.unsubscribe('compositionstart', compositionStart);

--- a/webodf/lib/gui/SelectionView.js
+++ b/webodf/lib/gui/SelectionView.js
@@ -62,7 +62,7 @@ gui.SelectionView.prototype.hide = function() { "use strict"; };
 
 /**
  * Clear all overlay from the DOM
- * @param {function(!Object=)} callback
+ * @param {function(!Error=)} callback
  * @return {undefined}
  */
 gui.SelectionView.prototype.destroy = function (callback) { "use strict"; };

--- a/webodf/lib/gui/SelectionViewManager.js
+++ b/webodf/lib/gui/SelectionViewManager.js
@@ -134,14 +134,14 @@ gui.SelectionViewManager = function SelectionViewManager(SelectionView) {
     };
 
     /**
-     * @param {function(!Object=)} callback
+     * @param {function(!Error=)} callback
      */
     this.destroy = function (callback) {
         var selectionViewArray = getSelectionViews();
 
         /**
          * @param {!number} i
-         * @param {!Object=} err
+         * @param {!Error=} err
          * @return {undefined}
          */
         function destroySelectionView(i, err) {

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -1030,7 +1030,7 @@
         }
 
         /**
-         * @param {!function(!Object=)} callback passing an error object in case of error
+         * @param {!function(!Error=)} callback passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function (callback) {

--- a/webodf/lib/gui/SessionView.js
+++ b/webodf/lib/gui/SessionView.js
@@ -384,7 +384,7 @@ gui.SessionViewOptions = function () {
         }
 
         /**
-         * @param {!function(!Object=)} callback, passing an error object in case of error
+         * @param {!function(!Error=)} callback, passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function (callback) {

--- a/webodf/lib/gui/SvgSelectionView.js
+++ b/webodf/lib/gui/SvgSelectionView.js
@@ -679,7 +679,7 @@ gui.SvgSelectionView = function SvgSelectionView(cursor) {
 
     /**
      * @inheritDoc
-     * @param {function(!Object=)} callback
+     * @param {function(!Error=)} callback
      */
     this.destroy = function (callback) {
         core.Async.destroyAll([renderTask.destroy, destroy], callback);

--- a/webodf/lib/gui/ZoomHelper.js
+++ b/webodf/lib/gui/ZoomHelper.js
@@ -479,7 +479,7 @@
         }
 
         /**
-         * @param {!function(!Object=)} callback, passing an error object in case of error
+         * @param {!function(!Error=)} callback, passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function (callback) {

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -151,7 +151,7 @@
         this.css = css;
 
         /**
-         * @param {!function(!Object=)} callback, passing an error object in case of error
+         * @param {!function(!Error=)} callback, passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function (callback) {
@@ -1588,7 +1588,7 @@
             }
         };
         /**
-         * @param {!function(!Object=)} callback, passing an error object in case of error
+         * @param {!function(!Error=)} callback, passing an error object in case of error
          * @return {undefined}
          */
         this.destroy = function(callback) {

--- a/webodf/lib/ops/EditInfo.js
+++ b/webodf/lib/ops/EditInfo.js
@@ -124,7 +124,7 @@ ops.EditInfo = function EditInfo(container, odtDocument) {
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -913,7 +913,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {

--- a/webodf/lib/ops/Session.js
+++ b/webodf/lib/ops/Session.js
@@ -145,7 +145,7 @@ ops.Session = function Session(odfCanvas) {
     };
 
     /**
-     * @param {!function(!Object=)} callback, passing an error object in case of error
+     * @param {!function(!Error=)} callback, passing an error object in case of error
      * @return {undefined}
      */
     this.destroy = function (callback) {


### PR DESCRIPTION
The currently plain undefined objects are not useful at all, because the properties are undefined.
Using `Error` (and subclasses) at least gives us `message` and `name` to rely on.
