### PR TITLE
make Webodf version a global property on the new namespace webodf

### DIFF
--- a/programs/benchmark/js/Benchmark.js
+++ b/programs/benchmark/js/Benchmark.js
@@ -84,16 +84,6 @@ define(["OdfBenchmarkContext"], function(OdfBenchmarkContext) {
                 currentActionIndex = -1;
                 executeNextAction();
             };
-
-            /**
-             * @returns {!string}
-             */
-            this.getWebODFVersion = function() {
-                return (typeof webodf_version !== "undefined"
-                    ? String(webodf_version)
-                    : "uncompiled"
-                    );
-            };
         }
 
         return Benchmark;

--- a/programs/benchmark/js/HTMLBenchmark.js
+++ b/programs/benchmark/js/HTMLBenchmark.js
@@ -107,7 +107,7 @@ define([
             benchmark = new Benchmark(canvasElement),
             renderer = new HTMLResultsRenderer(benchmark, benchmarkResultsElement);
 
-        versionElement.textContent = benchmark.getWebODFVersion();
+        versionElement.textContent = webodf.Version;
         renderer.setBackgroundColour(config.colour);
 
         loadingScreenElement.style.display = "none";

--- a/programs/viewer/ODFViewerPlugin.js
+++ b/programs/viewer/ODFViewerPlugin.js
@@ -36,7 +36,7 @@
  * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global runtime, document, odf, gui, console*/
+/*global runtime, document, odf, gui, console, webodf*/
 
 function ODFViewerPlugin() {
     "use strict";
@@ -216,11 +216,7 @@ function ODFViewerPlugin() {
     };
 
     this.getPluginVersion = function () {
-        var version = (String(typeof webodf_version) !== "undefined"
-            ? webodf_version
-            : "From Source"
-        );
-        return version;
+        return webodf.Version;
     };
 
     this.getPluginURL = function () {

--- a/webodf/lib/odf/OdfContainer.js
+++ b/webodf/lib/odf/OdfContainer.js
@@ -36,7 +36,7 @@
  * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global Node, NodeFilter, runtime, core, xmldom, odf, DOMParser, document, webodf_version */
+/*global Node, NodeFilter, runtime, core, xmldom, odf, DOMParser, document, webodf */
 
 
 (function () {
@@ -1123,11 +1123,7 @@
             var generatorString,
                 window = runtime.getWindow();
 
-            generatorString = "WebODF/" + (
-                String(typeof webodf_version) !== "undefined"
-                    ? webodf_version
-                    : "FromSource"
-            );
+            generatorString = "WebODF/" + webodf.Version;
 
             if (window) {
                 generatorString = generatorString + " " + window.navigator.userAgent;

--- a/webodf/lib/runtime.js
+++ b/webodf/lib/runtime.js
@@ -37,7 +37,7 @@
 /*global window, XMLHttpRequest, require, console, DOMParser, document,
   process, __dirname, setTimeout, Packages, print,
   readFile, quit, Buffer, ArrayBuffer, Uint8Array,
-  navigator, VBArray, alert, now, clearTimeout */
+  navigator, VBArray, alert, now, clearTimeout, webodf_version */
 /**
  * Three implementations of a runtime for browser, node.js and rhino.
  */
@@ -1667,6 +1667,30 @@ var odf = {};
  * @namespace The editing operations
  */
 var ops = {};
+
+/**
+ * @namespace The webodf namespace
+ */
+var webodf = {};
+
+(function () {
+    "use strict";
+    /**
+     * @return {string}
+     */
+    function getWebODFVersion() {
+        var version = (String(typeof webodf_version) !== "undefined"
+            ? webodf_version
+            : "From Source"
+        );
+        return version;
+    }
+    /**
+     * @const
+     * @type {!string}
+     */
+    webodf.Version = getWebODFVersion();
+}());
 
 /*jslint sloppy: true*/
 (function () {

--- a/webodf/tools/updateJS.js
+++ b/webodf/tools/updateJS.js
@@ -237,6 +237,7 @@ function Main(cmakeListPath) {
     function createCMakeLists(typed) {
         var path = cmakeListPath, content;
         content = "set(LIBJSFILES\n" +
+                // include webodfversion.js before runtime.js, latter uses var from the first
                 "    ${CMAKE_BINARY_DIR}/webodf/webodfversion.js\n" +
                 "    lib/runtime.js\n    lib/" +
                 typed.join("\n    lib/") + "\n)\n";


### PR DESCRIPTION
Commit is part of #465. It is done because with the About dialog of the editor there is another place which would estimate the version. So it is better to have it calculated once and then kept in a central place.

The "webodf" namespace seemed a good spot for it, so is getting introduced by this.
Also is in the long term "webodf" planned to be used as the namespace for all webodf sub-namespaces and variables, to avoid conflicts with other frameworks.

See also discussion in #465
