### PR TITLE
Fix crash in utf8ByteArrayToString when opening UTF8 heavy docs

### DIFF
--- a/webodf/lib/runtime.js
+++ b/webodf/lib/runtime.js
@@ -262,11 +262,20 @@ Runtime.byteArrayToString = function (bytearray, encoding) {
                     }
                 }
             }
-            if (chars.length === 1000) {
+            if (chars.length >= 1000) {
+                // more than 2 chars can be added in the above logic, so the length might exceed 1000
+
+                // Char-to-string conversion is done using apply as it provides a roughly %30 improvement vs.
+                // converting the characters 1-by-1, and improves memory usage significantly as well.
+
+                // However, the apply function has an upper limit on the size of the arguments array. If it is exceeded,
+                // most browsers with throw a RangeError. Avoid this problem by converting no more than 1000(ish)
+                // characters per call.
                 s += String.fromCharCode.apply(null, chars);
                 chars.length = 0;
             }
         }
+        // Based on the above chars.length check, there is guaranteed to be less than 1000 chars left in the array
         return s + String.fromCharCode.apply(null, chars);
     }
     var result;


### PR DESCRIPTION
UTF8 allows double-byte chars (as shown in the loop handling behaviour). This means that it's possible for the number of chars to never be exactly 1000. E.g., a double-byte char is added after there are 999 chars. If this happens, the char length will never flush until the function returns, at which point too many arguments are passed into the apply invocation and a maximum stack size error will be thrown.

There is no measurable performance from this change (tested @ 1000pages.odt)

This was discovered with this document: https://drive.google.com/file/d/0B1EH5OPb-RrjTEpqNkVTYV9zZjQ/edit?usp=sharing

(I'm testing various UTF8 documents from https://github.com/bits/UTF-8-Unicode-Test-Documents, converted with LibreOffice and loaded into the editor).
