### PR TITLE
Add OT for InsertText and SplitParagraph at the same position.

### DIFF
--- a/webodf/lib/ops/OperationTransformMatrix.js
+++ b/webodf/lib/ops/OperationTransformMatrix.js
@@ -598,22 +598,13 @@ ops.OperationTransformMatrix = function OperationTransformMatrix() {
     /**
      * @param {!ops.OpInsertText.Spec} insertTextSpec
      * @param {!ops.OpSplitParagraph.Spec} splitParagraphSpec
-     * @param {!boolean} hasAPriority
      * @return {?{opSpecsA:!Array.<!Object>, opSpecsB:!Array.<!Object>}}
      */
-    function transformInsertTextSplitParagraph(insertTextSpec, splitParagraphSpec, hasAPriority) {
-        if (insertTextSpec.position < splitParagraphSpec.position) {
+    function transformInsertTextSplitParagraph(insertTextSpec, splitParagraphSpec) {
+        if (insertTextSpec.position <= splitParagraphSpec.position) {
             splitParagraphSpec.position += insertTextSpec.text.length;
-        } else if (insertTextSpec.position > splitParagraphSpec.position) {
-            insertTextSpec.position += 1;
         } else {
-            if (hasAPriority) {
-                splitParagraphSpec.position += insertTextSpec.text.length;
-            } else {
-                insertTextSpec.position += 1;
-            }
-            // TODO: cursors get out of sync, so for now have OT fail
-            return null;
+            insertTextSpec.position += 1;
         }
 
         return {

--- a/webodf/tests/ops/transformationtests.xml
+++ b/webodf/tests/ops/transformationtests.xml
@@ -500,6 +500,48 @@
   </opsB>
   <after><office:text><text:p>a</text:p><text:p><c:cursor c:memberId="Bob"/></text:p><text:p><c:cursor c:memberId="Alice"/>b</text:p></office:text></after>
  </test>
+ <test name="InsertTextSplitParagraph_TaVT">
+  <before><office:text><text:p>TT</text:p></office:text></before>
+  <opsA>
+   <op optype="AddCursor" memberid="Alice"/>
+   <op optype="MoveCursor" memberid="Alice" position="1" length="0"/>
+   <op optype="InsertText" memberid="Alice" position="1" text="a" moveCursor="true"/>
+  </opsA>
+  <opsB>
+   <op optype="AddCursor" memberid="Bob"/>
+   <op optype="MoveCursor" memberid="Bob" position="1" length="0"/>
+   <op optype="SplitParagraph" memberid="Bob" position="1" moveCursor="true"/>
+  </opsB>
+  <after><office:text><text:p>Ta<c:cursor c:memberId="Alice"/></text:p><text:p><c:cursor c:memberId="Bob"/>T</text:p></office:text></after>
+ </test>
+ <test name="InsertTextSplitParagraph_TaTV">
+  <before><office:text><text:p>TT</text:p></office:text></before>
+  <opsA>
+   <op optype="AddCursor" memberid="Alice"/>
+   <op optype="MoveCursor" memberid="Alice" position="1" length="0"/>
+   <op optype="InsertText" memberid="Alice" position="1" text="a" moveCursor="true"/>
+  </opsA>
+  <opsB>
+   <op optype="AddCursor" memberid="Bob"/>
+   <op optype="MoveCursor" memberid="Bob" position="1" length="0"/>
+   <op optype="SplitParagraph" memberid="Bob" position="2" moveCursor="true"/>
+  </opsB>
+  <after><office:text><text:p>Ta<c:cursor c:memberId="Alice"/>T</text:p><text:p><c:cursor c:memberId="Bob"/></text:p></office:text></after>
+ </test>
+ <test name="InsertTextSplitParagraph_TVTa">
+  <before><office:text><text:p>TT</text:p></office:text></before>
+  <opsA>
+   <op optype="AddCursor" memberid="Alice"/>
+   <op optype="MoveCursor" memberid="Alice" position="1" length="0"/>
+   <op optype="InsertText" memberid="Alice" position="2" text="a" moveCursor="true"/>
+  </opsA>
+  <opsB>
+   <op optype="AddCursor" memberid="Bob"/>
+   <op optype="MoveCursor" memberid="Bob" position="1" length="0"/>
+   <op optype="SplitParagraph" memberid="Bob" position="1" moveCursor="true"/>
+  </opsB>
+  <after><office:text><text:p>T</text:p><text:p><c:cursor c:memberId="Bob"/>Ta<c:cursor c:memberId="Alice"/></text:p></office:text></after>
+ </test>
 
  <test name="RemoveTextRemoveText_{B}[CDE]">
   <before><office:text><text:p>ABCDEFG</text:p></office:text></before>


### PR DESCRIPTION
Very common showstopper.

The person typing text should keep typing in the same line without any unexpected jumps.
The person splitting the paragraph should get that without having the other typing in the new one.
