### PR TITLE
Fix Viewer crash when loading ODFViewerPlugin

### DIFF
--- a/programs/viewer/ODFViewerPlugin.js
+++ b/programs/viewer/ODFViewerPlugin.js
@@ -216,7 +216,15 @@ function ODFViewerPlugin() {
     };
 
     this.getPluginVersion = function () {
-        return webodf.Version;
+        var version;
+
+        if (String(typeof webodf) !== "undefined") {
+            version = webodf.Version;
+        } else {
+            version = "Unknown";
+        }
+
+        return version;
     };
 
     this.getPluginURL = function () {


### PR DESCRIPTION
Adds a check for the new `webodf` namespace before looking into it for version information in the `ODFViewerPlugin`. In the absence of such a check, there was a crash.

Till WebODF is available to the plugin, the version is presented as "unknown".
