### PR TITLE
Add ability to create empty presentation and spreadsheet.

### DIFF
--- a/webodf/tests/odf/LayoutTests.js
+++ b/webodf/tests/odf/LayoutTests.js
@@ -145,7 +145,7 @@ odf.LayoutTests = function LayoutTests(runner) {
      */
     function fillDocument(test, callback) {
         var officens = odf.Namespaces.officens,
-            odfContainer = new odf.OdfContainer("", null),
+            odfContainer = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null),
             root = odfContainer.rootElement,
             path = test.name + ".odt",
             input = test.input;

--- a/webodf/tests/odf/OdfContainerTests.js
+++ b/webodf/tests/odf/OdfContainerTests.js
@@ -75,8 +75,7 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
         });
     }
 
-    function createNew() {
-        t.odf = new odf.OdfContainer("", null);
+    function testEmptyDocument() {
         r.shouldBe(t, "t.odf.state", "odf.OdfContainer.DONE");
         r.shouldBeNonNull(t, "t.odf.rootElement");
         r.shouldBeNonNull(t, "t.odf.rootElement.meta");
@@ -89,9 +88,27 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
         r.shouldBeNonNull(t, "t.odf.rootElement.body");
     }
 
+    function createNewText() {
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
+        testEmptyDocument();
+        r.shouldBeNonNull(t, "t.odf.rootElement.text");
+    }
+
+    function createNewPresentation() {
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.PRESENTATION, null);
+        testEmptyDocument();
+        r.shouldBeNonNull(t, "t.odf.rootElement.presentation");
+    }
+
+    function createNewSpreadsheet() {
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.SPREADSHEET, null);
+        testEmptyDocument();
+        r.shouldBeNonNull(t, "t.odf.rootElement.spreadsheet");
+    }
+
     function setRootElement_OverwritesAllDocumentElements() {
         var originalProperties = {};
-        t.odf = new odf.OdfContainer("", null);
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         r.shouldBe(t, "t.odf.state", "odf.OdfContainer.DONE");
         t.originalRoot = t.odf.rootElement;
         // The properties values for the original root will change when it is disconnected from the document
@@ -117,7 +134,7 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
     }
 
     function createNewSaveAsAndLoad(callback) {
-        t.odf = new odf.OdfContainer("", null);
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         r.shouldBe(t, "t.odf.state", "odf.OdfContainer.DONE");
         t.odf.saveAs("test.odt", function (err) {
             t.err = err;
@@ -131,7 +148,7 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
     }
 
     function createNewSaveAsAndLoad_OptionalElement_SettingsXml(callback) {
-        t.odf = new odf.OdfContainer("", null);
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         r.shouldBe(t, "t.odf.state", "odf.OdfContainer.DONE");
         t.odf.rootElement.settings = null;
         t.odf.saveAs("test.odt", function (err) {
@@ -150,7 +167,7 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
     }
 
     function createNewSaveAsAndLoad_OptionalElement_MetaXml(callback) {
-        t.odf = new odf.OdfContainer("", null);
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         r.shouldBe(t, "t.odf.state", "odf.OdfContainer.DONE");
         t.odf.rootElement.meta = null;
         t.odf.saveAs("test.odt", function (err) {
@@ -168,7 +185,7 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
     }
 
     function doFontFaceDeclsSaveAsAndLoadRoundTrip(args, callback) {
-        t.odf = new odf.OdfContainer("", null);
+        t.odf = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         appendXmlsToNode(t.odf.rootElement.fontFaceDecls,   args.keptFontFaceDecls);
         appendXmlsToNode(t.odf.rootElement.fontFaceDecls,   args.droppedFontFaceDecls);
         appendXmlsToNode(t.odf.rootElement.styles,          args.styles);
@@ -331,7 +348,9 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
 */
     this.tests = function () {
         return r.name([
-            createNew,
+            createNewText,
+            createNewPresentation,
+            createNewSpreadsheet,
             setRootElement_OverwritesAllDocumentElements
         ]);
     };

--- a/webodf/tests/ops/OperationTests.js
+++ b/webodf/tests/ops/OperationTests.js
@@ -416,7 +416,7 @@ ops.OperationTests = function OperationTests(runner) {
         t = {};
         testarea = core.UnitTest.provideTestAreaDiv();
         t.odfcanvas = new odf.OdfCanvas(testarea);
-        t.odfContainer = new odf.OdfContainer("", null);
+        t.odfContainer = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         t.odfcanvas.setOdfContainer(t.odfContainer);
         t.odtDocument = new ops.OdtDocument(t.odfcanvas);
         properties = new ops.MemberProperties();

--- a/webodf/tests/ops/SessionTests.js
+++ b/webodf/tests/ops/SessionTests.js
@@ -49,7 +49,7 @@ ops.SessionTests = function SessionTests(runner) {
         t = {};
         testarea = core.UnitTest.provideTestAreaDiv();
         odfcanvas = new odf.OdfCanvas(testarea);
-        odfcanvas.setOdfContainer(new odf.OdfContainer("", null));
+        odfcanvas.setOdfContainer(new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null));
         t.odf = odfcanvas.odfContainer();
     };
     this.tearDown = function () {

--- a/webodf/tests/ops/TransformationTests.js
+++ b/webodf/tests/ops/TransformationTests.js
@@ -381,7 +381,7 @@ ops.TransformationTests = function TransformationTests(runner) {
             i,
             op;
 
-        odfContainer = new odf.OdfContainer("", null);
+        odfContainer = new odf.OdfContainer(odf.OdfContainer.DocumentType.TEXT, null);
         t.odfcanvas.setOdfContainer(odfContainer);
         odtDocument = new ops.OdtDocument(t.odfcanvas);
         text = odtDocument.getRootNode();


### PR DESCRIPTION
To create an empty document in odf.OdfContainer, the type of the document should be passed. If a string is passed, it is interpreted as url and an attempt is made to load a document from that url.
