### PR TITLE
Ensure each bookmark is only present ONCE in the step-to-DOM point cache

### DIFF
--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -1688,7 +1688,7 @@
   </ops>
   <after><office:text><text:p><text:span>abc<c:cursor c:memberId="Joe"/></text:span><text:span> <text:s> </text:s>ef</text:span></text:p></office:text></after>
  </test>
- <test name="CacheBugCheck_EnsureProperBookmarkMaintenance" isFailing="true">
+ <test name="CacheBugCheck_EnsureProperBookmarkMaintenance">
   <before>
    <office:text><text:p/><text:p/></office:text>
   </before>
@@ -1717,7 +1717,7 @@
    <office:text><text:p>DEF</text:p><text:p><c:cursor c:memberId="Joe"/></text:p></office:text>.
   </after>
  </test>
- <test name="RemoveText_aroundInlineRootWithoutBreakingPositionsBehind_insertingLotsOfDots" isFailing="true">
+ <test name="RemoveText_aroundInlineRootWithoutBreakingPositionsBehind_insertingLotsOfDots">
   <!--- happened when simulating github issue #417 -->
   <before>
    <office:text><text:p/><text:p>ABCDEFGH</text:p><text:p>12345678</text:p></office:text>


### PR DESCRIPTION
Allowing the same bookmark to appear multiple times in this particular cache causes major headaches when the bookmark is updated, as EACH step-to-DOM (s2D) entry pointing to the bookmark would also need to be updated.

As there is no real performance benefit from having the same bookmark appear multiple times, life is made significantly simpler by only allowing the bookmark to appear a maximum of once in the s2D cache.

See new operation test for reproduction steps... these are rather arcane as they were discovered Bella.
