### PR TITLE
use the new official name "ViewerJS" consistently everywhere

### DIFF
--- a/programs/viewer/example.local.css
+++ b/programs/viewer/example.local.css
@@ -4,9 +4,9 @@
 
 @font-face {
   font-family: 'Novecentowide Book';
-  src: url("/Viewer.js/fonts/Novecentowide-Bold-webfont.eot");
-  src: url("/Viewer.js/fonts/Novecentowide-Bold-webfont.eot?#iefix") format("embedded-opentype"), 
-  url("/Viewer.js/fonts/Novecentowide-Bold-webfont.woff") format("woff"), 
+  src: url("/ViewerJS/fonts/Novecentowide-Bold-webfont.eot");
+  src: url("/ViewerJS/fonts/Novecentowide-Bold-webfont.eot?#iefix") format("embedded-opentype"),
+  url("/ViewerJS/fonts/Novecentowide-Bold-webfont.woff") format("woff"),
   url("/fonts/Novecentowide-Bold-webfont.ttf") format("truetype"), 
   url("/fonts/Novecentowide-Bold-webfont.svg#NovecentowideBookBold") format("svg");
   font-weight: normal;
@@ -15,11 +15,11 @@
 
 @font-face {
     font-family: 'exotica';
-    src: url('/Viewer.js/fonts/Exotica-webfont.eot');
-    src: url('/Viewer.js/fonts/Exotica-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/Viewer.js/fonts/Exotica-webfont.woff') format('woff'),
-         url('/Viewer.js/fonts/Exotica-webfont.ttf') format('truetype'),
-         url('/Viewer.js/fonts/Exotica-webfont.svg#exoticamedium') format('svg');
+    src: url('/ViewerJS/fonts/Exotica-webfont.eot');
+    src: url('/ViewerJS/fonts/Exotica-webfont.eot?#iefix') format('embedded-opentype'),
+         url('/ViewerJS/fonts/Exotica-webfont.woff') format('woff'),
+         url('/ViewerJS/fonts/Exotica-webfont.ttf') format('truetype'),
+         url('/ViewerJS/fonts/Exotica-webfont.svg#exoticamedium') format('svg');
     font-weight: normal;
     font-style: normal;
 


### PR DESCRIPTION
actually only one place with viewer.js here
