### PR TITLE
Suppress manual task processing to prevent skewing of benchmark figures

### DIFF
--- a/programs/benchmark/js/Benchmark.js
+++ b/programs/benchmark/js/Benchmark.js
@@ -40,6 +40,7 @@ define(["OdfBenchmarkContext"], function(OdfBenchmarkContext) {
         "use strict";
 
         runtime.loadClass("core.EventNotifier");
+        runtime.loadClass("core.Task");
         runtime.loadClass("odf.OdfCanvas");
 
         /**
@@ -80,6 +81,7 @@ define(["OdfBenchmarkContext"], function(OdfBenchmarkContext) {
                 });
 
                 events.emit("start", {});
+                core.Task.SUPPRESS_MANUAL_PROCESSING = true;
                 context.odfCanvas = new odf.OdfCanvas(canvasElement);
                 currentActionIndex = -1;
                 executeNextAction();

--- a/webodf/lib/core/Task.js
+++ b/webodf/lib/core/Task.js
@@ -91,13 +91,23 @@
     core.Task =  {};
 
     /**
+     * Disable manually processing of tasks when core.Task.processTasks is called.
+     * This is only used during benchmarks to prevent caret redraws from skewing
+     * the resulting numbers
+     * @type {!boolean}
+     */
+    core.Task.SUPPRESS_MANUAL_PROCESSING = false;
+
+    /**
      * Process any outstanding redraw tasks that may be queued up
      * waiting for an animation frame
      * 
      * @return {undefined}
      */
     core.Task.processTasks = function() {
-        redrawTasks.performRedraw();
+        if (!core.Task.SUPPRESS_MANUAL_PROCESSING) {
+            redrawTasks.performRedraw();
+        }
     };
 
     /**


### PR DESCRIPTION
Manually processing the redraw tasks vastly affects the current benchmark results, dwarfing impacts from most other subsystems. Disabling this for now to aid tuning of non-UI components.
