### PR TITLE
Do not let the caret overlay grab pointer events.

### DIFF
--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -242,6 +242,7 @@ cursor|cursor {
     height: 1em;
     margin-left: -1px;
     z-index: 10;
+    pointer-events: none;
 }
 
 .webodf-caretOverlay .caret {


### PR DESCRIPTION
Clicking on the caret causes the cursor to move to either the end or beginning of the document.
This is especially noticeable when double-clicking in a word.

Was introduced by overlay-ification of the caret. Fixable by making the caret stop taking pointer events.
