### PR TITLE
Restore opacity: 0.3; as default for avatar handles

### DIFF
--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -260,6 +260,7 @@ cursor|cursor {
     width: 64px !important;
     height: 68px !important;
     border-radius: 5px;
+    opacity: 0.3;
     text-align: center;
     background-color: black !important;
     box-shadow: 0px 0px 5px rgb(90, 90, 90);


### PR DESCRIPTION
accidentally removed in 234380ef335a18aede408dcb4883155b1113e896
