### PR TITLE
Set element.style.display to "inline-block" also in OdfCanvas' refreshOdf()

### DIFF
--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1169,6 +1169,8 @@
 
             element.style.width = Math.round(zoomLevel * sizer.offsetWidth) + "px";
             element.style.height = Math.round(zoomLevel * sizer.offsetHeight) + "px";
+            // Re-apply inline-block to canvas element on resizing.
+            // Chrome tends to forget this property after a relayout
             element.style.display = "inline-block";
         }
 
@@ -1298,6 +1300,7 @@
                 clear(element);
 
                 // setup
+                element.style.display = "inline-block";
                 var odfnode = odfcontainer.rootElement;
                 element.ownerDocument.importNode(odfnode, true);
 


### PR DESCRIPTION
Fixes the initial display of documents with no annotations or if disabled

Fixup for 3ae91bbfdd5d33224748fcbe16184376e6a15799

Reason is that fixContainerSize() would not have been called in such cases, thus element.style.display never  been set initially
