### PR TITLE
Simplify the detection of android.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,14 +265,15 @@ if (NOT ANT)
 endif(NOT ANT)
 
 # Android
-if (NOT ANDROID_SDK_DIR)
-  if(WIN32)
-    find_path(ANDROID_SDK_DIR platform-tools/aapt.exe)
-  else()
-    find_path(ANDROID_SDK_DIR platform-tools/aapt)
-  endif()
-endif(NOT ANDROID_SDK_DIR)
-
+# If android sdk is properly installed, cmake only needs to know where to find
+# the executable 'android'.
+# The variable ANDROID_SDK_DIR can be provided if a specific android sdk version
+# is desired or if the android executable is not in the path.
+if (ANDROID_SDK_DIR)
+  set(ANDROID ${ANDROID_SDK_DIR}/tools/android)
+else (ANDROID_SDK_DIR)
+  find_program(ANDROID android)
+endif(ANDROID_SDK_DIR)
 
 ##############################
 ## Define custom macros

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -5,9 +5,9 @@ if(BUILD_QTJSRUNTIME)
 #   add_subdirectory(nativeQtClient)
 endif(BUILD_QTJSRUNTIME)
 
-if(ANDROID_SDK_DIR AND ANT)
+if(ANDROID AND ANT)
   add_subdirectory(android)
-endif(ANDROID_SDK_DIR AND ANT)
+endif(ANDROID AND ANT)
 
 add_subdirectory(docnosis)
 

--- a/programs/android/CMakeLists.txt
+++ b/programs/android/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(ANDROID_JAR ${ANDROID_SDK_DIR}/platforms/android-8/android.jar)
-
 # Windows requires Ant binary
 if(WIN32)
     set(APKDEPS AntBin)
@@ -31,7 +29,7 @@ COPY_FILES(APKDEPS ${CMAKE_BINARY_DIR}/webodf
 set(WEBODFAPK ${CMAKE_CURRENT_BINARY_DIR}/bin/WebODF-debug.apk)
 add_custom_command(
     OUTPUT ${WEBODFAPK}
-    COMMAND ${ANDROID_SDK_DIR}/tools/android
+    COMMAND ${ANDROID}
         ARGS update project --path . --target android-7 --name WebODF
     COMMAND ${ANT}
         ARGS -lib ${CMAKE_CURRENT_SOURCE_DIR}/libs/cordova-1.8.0.jar debug


### PR DESCRIPTION
Instead of a variable that points to a directory, use the path to the android executable. This makes building the apk more robust.
