### PR TITLE
Return only operation specs as transformation result, not operation objects

### DIFF
--- a/programs/editor/server/pullbox/OperationRouter.js
+++ b/programs/editor/server/pullbox/OperationRouter.js
@@ -239,14 +239,14 @@ define("webodf/editor/server/pullbox/OperationRouter", [], function () {
             }
 
             // store transformed server ops
-            for (i = 0; i < transformResult.opsB.length; i += 1) {
-                unplayedServerOpspecQueue.push(transformResult.opsB[i].spec());
+            for (i = 0; i < transformResult.opSpecsB.length; i += 1) {
+                unplayedServerOpspecQueue.push(transformResult.opSpecsB[i]);
             }
 
             // store opspecs of all transformed client opspecs
             unsyncedClientOpspecQueue = [];
-            for (i = 0; i < transformResult.opsA.length; i += 1) {
-                unsyncedClientOpspecQueue.push(transformResult.opsA[i].spec());
+            for (i = 0; i < transformResult.opSpecsA.length; i += 1) {
+                unsyncedClientOpspecQueue.push(transformResult.opSpecsA[i]);
             }
 
             return true;
@@ -467,7 +467,6 @@ runtime.log("OperationRouter: instant opsSync requested");
          */
         this.setOperationFactory = function (f) {
             operationFactory = f;
-            operationTransformer.setOperationFactory(f);
         };
 
         /**

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -435,7 +435,6 @@
         "ops.OpUpdateParagraphStyle"
     ],
     "ops.OperationTransformer": [
-        "ops.OperationFactory",
         "ops.OperationTransformMatrix"
     ],
     "ops.Server": [

--- a/webodf/lib/ops/OperationTransformer.js
+++ b/webodf/lib/ops/OperationTransformer.js
@@ -36,23 +36,7 @@
 ops.OperationTransformer = function OperationTransformer() {
     "use strict";
 
-    var /**@type{!ops.OperationFactory}}*/
-        operationFactory,
-        operationTransformMatrix = new ops.OperationTransformMatrix();
-
-    /**
-     * @param {!Array.<!{optype:string}>} opspecs
-     * @return {!Array.<!ops.Operation>}
-     */
-    function operations(opspecs) {
-        var ops = [];
-
-        opspecs.forEach(function (opspec) {
-            ops.push(operationFactory.create(opspec));
-        });
-
-        return ops;
-    }
+    var operationTransformMatrix = new ops.OperationTransformMatrix();
 
     /**
      * TODO: priority could be read from op spec, here be an attribute from-server
@@ -121,16 +105,6 @@ ops.OperationTransformer = function OperationTransformer() {
     }
 
     /**
-     * Sets the factory to use to create operation instances from operation specs.
-     *
-     * @param {!ops.OperationFactory} f
-     * @return {undefined}
-     */
-    this.setOperationFactory = function (f) {
-        operationFactory = f;
-    };
-
-    /**
      * @return {!ops.OperationTransformMatrix}
      */
     this.getOperationTransformMatrix = function () {
@@ -140,8 +114,8 @@ ops.OperationTransformer = function OperationTransformer() {
     /**
      * @param {!Array.<!Object>} opSpecsA   sequence of opspecs with lower priority in case of tie breaking
      * @param {!Array.<!{optype:string}>} opSpecsB   opspecs with higher priority in case of tie breaking
-     * @return {?{opsA:Array.<!ops.Operation>,
-     *            opsB:Array.<!ops.Operation>}}
+     * @return {?{opSpecsA:!Array.<!Object>,
+     *            opSpecsB:!Array.<!Object>}}
      */
     this.transform = function (opSpecsA, opSpecsB) {
         var transformResult,
@@ -160,8 +134,8 @@ ops.OperationTransformer = function OperationTransformer() {
         }
 
         return {
-            opsA: operations(opSpecsA),
-            opsB: operations(transformedOpspecsB)
+            opSpecsA: /**@type{!Array.<!Object>}*/(opSpecsA),
+            opSpecsB: /**@type{!Array.<!Object>}*/(transformedOpspecsB)
         };
     };
 };

--- a/webodf/tests/manifest.json
+++ b/webodf/tests/manifest.json
@@ -163,6 +163,7 @@
         "odf.OdfCanvas",
         "odf.OdfContainer",
         "ops.OdtDocument",
+        "ops.Operation",
         "ops.OperationFactory",
         "ops.OperationTransformer",
         "xmldom.LSSerializer"
@@ -170,7 +171,6 @@
     "ops.TransformerTests": [
         "core.UnitTester",
         "odf.OdfCanvas",
-        "ops.OperationFactory",
         "ops.OperationTransformer"
     ],
     "xmldom.LSSerializerTests": [

--- a/webodf/tests/ops/TransformationTests.js
+++ b/webodf/tests/ops/TransformationTests.js
@@ -75,6 +75,20 @@ ops.TransformationTests = function TransformationTests(runner) {
     }
 
     /**
+     * @param {!Array.<!{optype:string}>} opspecs
+     * @return {!Array.<!ops.Operation>}
+     */
+    function operations(opspecs) {
+        var ops = [];
+
+        opspecs.forEach(function (opspec) {
+            ops.push(t.operationFactory.create(opspec));
+        });
+
+        return ops;
+    }
+
+    /**
      * Traverse the tree and sort cursors that are at the same position,
      * so identic sets of cursors are in an identic order.
      * @param {!Element} element
@@ -366,7 +380,7 @@ ops.TransformationTests = function TransformationTests(runner) {
         return getOfficeNSElement(element, "meta");
     }
 
-    function compareOpsExecution(opspecs, transformedOps, before, after) {
+    function compareOpsExecution(opspecs, transformedOpspecs, before, after) {
         var odfContainer,
             odtDocument,
             text,
@@ -378,6 +392,7 @@ ops.TransformationTests = function TransformationTests(runner) {
             meta,
             metabefore = getOfficeMetaElement(before),
             metaafter = getOfficeMetaElement(after),
+            transformedOps = operations(transformedOpspecs),
             i,
             op;
 
@@ -463,12 +478,11 @@ ops.TransformationTests = function TransformationTests(runner) {
     function runTest(test) {
         var transformer = new ops.OperationTransformer();
 
-        transformer.setOperationFactory(t.operationFactory);
         t.transformResult = transformer.transform(cloneSpecs(test.opspecsA), cloneSpecs(test.opspecsB));
         r.shouldBeNonNull(t, "t.transformResult");
         if (t.transformResult) {
-            compareOpsExecution(test.opspecsA, t.transformResult.opsB, test.before, test.after);
-            compareOpsExecution(test.opspecsB, t.transformResult.opsA, test.before, test.after);
+            compareOpsExecution(test.opspecsA, t.transformResult.opSpecsB, test.before, test.after);
+            compareOpsExecution(test.opspecsB, t.transformResult.opSpecsA, test.before, test.after);
         }
     }
 

--- a/webodf/tests/ops/TransformerTests.js
+++ b/webodf/tests/ops/TransformerTests.js
@@ -145,14 +145,6 @@ ops.TransformerTests = function TransformerTests(runner) {
         };
     }
 
-    function opspecs(ops) {
-        var i, result = [];
-        for (i = 0; i < ops.length; i += 1) {
-            result.push(ops[i].spec());
-        }
-        return result;
-    }
-
     /**
      * Creates a deep copy of the spec
      * @param {!Object} object
@@ -181,12 +173,11 @@ ops.TransformerTests = function TransformerTests(runner) {
         var transformer = new ops.OperationTransformer(),
             i;
 
-        transformer.setOperationFactory(t.operationFactory);
         t.transformResult = transformer.transform(cloneSpecs(test["in"].opspecsA), cloneSpecs(test["in"].opspecsB));
         r.shouldBeNonNull(t, "t.transformResult");
         if (t.transformResult) {
-            t.transformedOpspecsA = opspecs(t.transformResult.opsA);
-            t.transformedOpspecsB = opspecs(t.transformResult.opsB);
+            t.transformedOpspecsA = t.transformResult.opSpecsA;
+            t.transformedOpspecsB = t.transformResult.opSpecsB;
             t.refOpspecsA = test.out.opspecsA;
             t.refOpspecsB = test.out.opspecsB;
 
@@ -261,7 +252,6 @@ ops.TransformerTests = function TransformerTests(runner) {
         t = {};
         testarea = core.UnitTest.provideTestAreaDiv();
         t.odfcanvas = new odf.OdfCanvas(testarea);
-        t.operationFactory = new ops.OperationFactory();
     };
     this.tearDown = function () {
         t = {};


### PR DESCRIPTION
Those consumers who need operation objects can create those themselves. Many do not,like the Pullbox operation router.
