### PR TITLE
remove no more needed returning of the class constructor at end of class files

### DIFF
--- a/webodf/lib/core/DomUtils.js
+++ b/webodf/lib/core/DomUtils.js
@@ -933,6 +933,4 @@
         }
         init(this);
     };
-
-    return core.DomUtils;
 }());

--- a/webodf/lib/core/PositionFilter.js
+++ b/webodf/lib/core/PositionFilter.js
@@ -52,7 +52,3 @@ core.PositionFilter.FilterResult = {
  * @return {!core.PositionFilter.FilterResult}
  */
 core.PositionFilter.prototype.acceptPosition = function (point) {"use strict"; };
-(function () {
-    "use strict";
-    return core.PositionFilter;
-}());

--- a/webodf/lib/gui/AnnotationController.js
+++ b/webodf/lib/gui/AnnotationController.js
@@ -204,9 +204,3 @@ gui.AnnotationController = function AnnotationController(session, inputMemberId)
 };
 
 /**@const*/gui.AnnotationController.annotatableChanged = "annotatable/changed";
-
-(function () {
-    "use strict";
-    return gui.AnnotationController;
-}());
-

--- a/webodf/lib/gui/DirectFormattingController.js
+++ b/webodf/lib/gui/DirectFormattingController.js
@@ -804,9 +804,3 @@ gui.DirectFormattingController = function DirectFormattingController(session, in
 
 /**@const*/gui.DirectFormattingController.textStylingChanged = "textStyling/changed";
 /**@const*/gui.DirectFormattingController.paragraphStylingChanged = "paragraphStyling/changed";
-
-(function () {
-    "use strict";
-    return gui.DirectFormattingController;
-}());
-

--- a/webodf/lib/gui/InputMethodEditor.js
+++ b/webodf/lib/gui/InputMethodEditor.js
@@ -341,6 +341,4 @@
      * @type {!string}
      */
     gui.InputMethodEditor.signalCompositionEnd = "input/compositionend";
-
-    return gui.InputMethodEditor;
 }());

--- a/webodf/lib/gui/KeyboardHandler.js
+++ b/webodf/lib/gui/KeyboardHandler.js
@@ -226,8 +226,3 @@ gui.KeyboardHandler.KeyCode = {
     RightMeta: 93,
     MetaInMozilla: 224
 };
-
-(function () {
-    "use strict";
-    return gui.KeyboardHandler;
-}());

--- a/webodf/lib/gui/SelectionMover.js
+++ b/webodf/lib/gui/SelectionMover.js
@@ -413,7 +413,3 @@ gui.SelectionMover.createPositionIterator = function (rootNode) {
     var filter = new CursorFilter();
     return new core.PositionIterator(rootNode, 5, filter, false);
 };
-(function () {
-    "use strict";
-    return gui.SelectionMover;
-}());

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -1185,7 +1185,5 @@ gui.SessionControllerOptions = function () {
 
         init();
     };
-
-    return gui.SessionController;
 }());
 // vim:expandtab

--- a/webodf/lib/gui/ShadowCursor.js
+++ b/webodf/lib/gui/ShadowCursor.js
@@ -116,8 +116,3 @@ gui.ShadowCursor = function ShadowCursor(document) {
 };
 
 /** @const @type {!string} */gui.ShadowCursor.ShadowCursorMemberId = "";
-
-(function () {
-    "use strict";
-    return gui.ShadowCursor;
-}());

--- a/webodf/lib/gui/TextController.js
+++ b/webodf/lib/gui/TextController.js
@@ -278,9 +278,3 @@ gui.TextController = function TextController(session, inputMemberId, directStyle
     }
     this.insertText = insertText;
 };
-
-(function () {
-    "use strict";
-    return gui.TextController;
-}());
-

--- a/webodf/lib/gui/TrivialUndoManager.js
+++ b/webodf/lib/gui/TrivialUndoManager.js
@@ -377,8 +377,3 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
 };
 
 /**@const*/ gui.TrivialUndoManager.signalDocumentRootReplaced = "documentRootReplaced";
-
-(function() {
-    "use strict";
-    return gui.TrivialUndoManager;
-}());

--- a/webodf/lib/gui/UndoManager.js
+++ b/webodf/lib/gui/UndoManager.js
@@ -127,8 +127,3 @@ gui.UndoManager.prototype.onOperationExecuted = function (op) {"use strict"; };
 /**@const*/gui.UndoManager.signalUndoStackChanged = "undoStackChanged";
 /**@const*/gui.UndoManager.signalUndoStateCreated = "undoStateCreated";
 /**@const*/gui.UndoManager.signalUndoStateModified = "undoStateModified";
-
-(function () {
-    "use strict";
-    return gui.UndoManager;
-}());

--- a/webodf/lib/odf/FontLoader.js
+++ b/webodf/lib/odf/FontLoader.js
@@ -173,5 +173,4 @@
             }
         };
     };
-    return odf.FontLoader;
 }());

--- a/webodf/lib/odf/OdfContainer.js
+++ b/webodf/lib/odf/OdfContainer.js
@@ -1328,7 +1328,6 @@
     odf.OdfContainer.getContainer = function (url) {
         return new odf.OdfContainer(url, null);
     };
-    return odf.OdfContainer;
 }());
 /**
  * @enum {number}

--- a/webodf/lib/odf/WordBoundaryFilter.js
+++ b/webodf/lib/odf/WordBoundaryFilter.js
@@ -211,8 +211,3 @@ odf.WordBoundaryFilter.IncludeWhitespace = {
     /**@const*/TRAILING: 1,
     /**@const*/LEADING: 2
 };
-
-(function() {
-    "use strict";
-    return odf.WordBoundaryFilter;
-}());

--- a/webodf/lib/ops/OdtCursor.js
+++ b/webodf/lib/ops/OdtCursor.js
@@ -211,8 +211,3 @@ ops.OdtCursor.RegionSelection = 'Region';
 /**@const
  @type {!string} */
 ops.OdtCursor.signalCursorUpdated = "cursorUpdated";
-
-(function () {
-    "use strict";
-    return ops.OdtCursor;
-}());

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -992,9 +992,4 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
 /**@const*/ops.OdtDocument.signalStepsRemoved = "steps/removed";
 /**@const*/ops.OdtDocument.signalMetadataUpdated = "metadata/updated";
 
-(function () {
-    "use strict";
-    return ops.OdtDocument;
-}());
-
 // vim:expandtab

--- a/webodf/lib/ops/OdtStepsTranslator.js
+++ b/webodf/lib/ops/OdtStepsTranslator.js
@@ -327,6 +327,4 @@
      * @type {!number}
      */
     ops.OdtStepsTranslator.NEXT_STEP = NEXT_STEP;
-
-    return ops.OdtStepsTranslator;
 }());

--- a/webodf/tests/core/CursorTests.js
+++ b/webodf/tests/core/CursorTests.js
@@ -213,7 +213,3 @@ core.CursorTests.prototype.description = function () {
     "use strict";
     return "Test the Cursor class.";
 };
-(function () {
-    "use strict";
-    return core.CursorTests;
-}());

--- a/webodf/tests/core/DomUtilsTests.js
+++ b/webodf/tests/core/DomUtilsTests.js
@@ -700,7 +700,3 @@ core.DomUtilsTests.prototype.description = function () {
     "use strict";
     return "Test the DomUtils class.";
 };
-(function () {
-    "use strict";
-    return core.DomUtilsTests;
-}());

--- a/webodf/tests/core/PositionIteratorTests.js
+++ b/webodf/tests/core/PositionIteratorTests.js
@@ -623,7 +623,3 @@ core.PositionIteratorTests.prototype.description = function () {
     "use strict";
     return "Test the PositionIterator class.";
 };
-(function () {
-    "use strict";
-    return core.PositionIteratorTests;
-}());

--- a/webodf/tests/core/StepIteratorTests.js
+++ b/webodf/tests/core/StepIteratorTests.js
@@ -236,7 +236,3 @@ core.StepIteratorTests.prototype.description = function () {
     "use strict";
     return "Test the StepIterator class.";
 };
-(function () {
-    "use strict";
-    return core.StepIteratorTests;
-}());

--- a/webodf/tests/core/ZipTests.js
+++ b/webodf/tests/core/ZipTests.js
@@ -176,7 +176,3 @@ core.ZipTests.prototype.description = function () {
     "use strict";
     return "Test the Zip class.";
 };
-(function () {
-    "use strict";
-    return core.ZipTests;
-}());

--- a/webodf/tests/gui/SelectionControllerTests.js
+++ b/webodf/tests/gui/SelectionControllerTests.js
@@ -575,7 +575,3 @@ gui.SelectionControllerTests.prototype.description = function () {
     "use strict";
     return "Test the SelectionController class.";
 };
-(function () {
-    "use strict";
-    return gui.SelectionControllerTests;
-}());

--- a/webodf/tests/gui/StyleSummaryTests.js
+++ b/webodf/tests/gui/StyleSummaryTests.js
@@ -321,7 +321,3 @@ gui.StyleSummaryTests.prototype.description = function () {
     "use strict";
     return "Test the StyleSummary class.";
 };
-(function () {
-    "use strict";
-    return gui.StyleSummaryTests;
-}());

--- a/webodf/tests/gui/TrivialUndoManagerTests.js
+++ b/webodf/tests/gui/TrivialUndoManagerTests.js
@@ -396,7 +396,3 @@ gui.TrivialUndoManagerTests.prototype.description = function () {
     "use strict";
     return "Test the TrivialUndoManager class.";
 };
-(function () {
-    "use strict";
-    return gui.TrivialUndoManagerTests;
-}());

--- a/webodf/tests/gui/UndoStateRulesTests.js
+++ b/webodf/tests/gui/UndoStateRulesTests.js
@@ -408,7 +408,3 @@ gui.UndoStateRulesTests.prototype.description = function () {
     "use strict";
     return "Test the UndoStateRules class.";
 };
-(function () {
-    "use strict";
-    return gui.UndoStateRulesTests;
-}());

--- a/webodf/tests/odf/FormattingTests.js
+++ b/webodf/tests/odf/FormattingTests.js
@@ -515,7 +515,3 @@ odf.FormattingTests.prototype.description = function () {
     "use strict";
     return "Test the Formatting class.";
 };
-(function () {
-    "use strict";
-    return odf.FormattingTests;
-}());

--- a/webodf/tests/odf/LayoutTests.js
+++ b/webodf/tests/odf/LayoutTests.js
@@ -329,7 +329,3 @@ odf.LayoutTests.prototype.description = function () {
     "use strict";
     return "Test that the layout of the odf documents is calculated correctly.";
 };
-(function () {
-    "use strict";
-    return odf.LayoutTests;
-}());

--- a/webodf/tests/odf/ListStyleToCssTests.js
+++ b/webodf/tests/odf/ListStyleToCssTests.js
@@ -369,7 +369,3 @@ odf.ListStyleToCssTests.prototype.description = function () {
     "use strict";
     return "Test the ListStyleToCss class.";
 };
-(function () {
-    "use strict";
-    return odf.ListStyleToCssTests;
-}());

--- a/webodf/tests/odf/ObjectNameGeneratorTests.js
+++ b/webodf/tests/odf/ObjectNameGeneratorTests.js
@@ -164,7 +164,3 @@ odf.ObjectNameGeneratorTests.prototype.description = function () {
     "use strict";
     return "Test the ObjectNameGenerator class.";
 };
-(function () {
-    "use strict";
-    return odf.ObjectNameGeneratorTests;
-}());

--- a/webodf/tests/odf/OdfContainerTests.js
+++ b/webodf/tests/odf/OdfContainerTests.js
@@ -371,7 +371,3 @@ odf.OdfContainerTests.prototype.description = function () {
     "use strict";
     return "Test the OdfContainer class.";
 };
-(function () {
-    "use strict";
-    return odf.OdfContainerTests;
-}());

--- a/webodf/tests/odf/OdfUtilsTests.js
+++ b/webodf/tests/odf/OdfUtilsTests.js
@@ -452,7 +452,3 @@ odf.OdfUtilsTests.prototype.description = function () {
     "use strict";
     return "Test the OdfUtilsTests class.";
 };
-(function () {
-    "use strict";
-    return odf.OdfUtilsTests;
-}());

--- a/webodf/tests/odf/StyleCacheTests.js
+++ b/webodf/tests/odf/StyleCacheTests.js
@@ -102,7 +102,3 @@ odf.StyleCacheTests.prototype.description = function () {
     "use strict";
     return "Test that the styles of the odf documents are calculated correctly.";
 };
-(function () {
-    "use strict";
-    return odf.StyleCacheTests;
-}());

--- a/webodf/tests/odf/StyleInfoTests.js
+++ b/webodf/tests/odf/StyleInfoTests.js
@@ -98,7 +98,3 @@ odf.StyleInfoTests.prototype.description = function () {
     "use strict";
     return "Test the StyleInfo class.";
 };
-(function () {
-    "use strict";
-    return odf.StyleInfoTests;
-}());

--- a/webodf/tests/odf/StyleParseUtilsTests.js
+++ b/webodf/tests/odf/StyleParseUtilsTests.js
@@ -98,7 +98,3 @@ odf.StyleParseUtilsTests.prototype.description = function () {
     "use strict";
     return "Test the methods of StyleParseUtils.";
 };
-(function () {
-    "use strict";
-    return odf.StyleParseUtilsTests;
-}());

--- a/webodf/tests/odf/TextStyleApplicatorTests.js
+++ b/webodf/tests/odf/TextStyleApplicatorTests.js
@@ -409,7 +409,3 @@ odf.TextStyleApplicatorTests.prototype.description = function () {
     "use strict";
     return "Test the TextStyleApplicator class.";
 };
-(function () {
-    "use strict";
-    return odf.TextStyleApplicatorTests;
-}());

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -849,7 +849,3 @@ ops.OdtDocumentTests.prototype.description = function () {
     "use strict";
     return "Test the OdtDocument class.";
 };
-(function () {
-    "use strict";
-    return ops.OdtDocumentTests;
-}());

--- a/webodf/tests/ops/OdtStepsTranslatorTests.js
+++ b/webodf/tests/ops/OdtStepsTranslatorTests.js
@@ -705,7 +705,3 @@ ops.OdtStepsTranslatorTests.prototype.description = function () {
     "use strict";
     return "Test the OdtStepsTranslator class.";
 };
-(function () {
-    "use strict";
-    return ops.OdtStepsTranslatorTests;
-}());

--- a/webodf/tests/ops/OperationTests.js
+++ b/webodf/tests/ops/OperationTests.js
@@ -490,7 +490,3 @@ ops.OperationTests.prototype.description = function () {
     "use strict";
     return "Test the ODT operations described in an XML file.";
 };
-(function () {
-    "use strict";
-    return ops.OperationTests;
-}());

--- a/webodf/tests/ops/SessionTests.js
+++ b/webodf/tests/ops/SessionTests.js
@@ -76,7 +76,3 @@ ops.SessionTests.prototype.description = function () {
     "use strict";
     return "Test the Session class.";
 };
-(function () {
-    "use strict";
-    return ops.SessionTests;
-}());

--- a/webodf/tests/ops/TransformationTests.js
+++ b/webodf/tests/ops/TransformationTests.js
@@ -558,7 +558,3 @@ ops.TransformationTests.prototype.description = function () {
     "use strict";
     return "Test the transformations of ODT operations described in an XML file on consistent ODT dom results.";
 };
-(function () {
-    "use strict";
-    return ops.TransformationTests;
-}());

--- a/webodf/tests/ops/TransformerTests.js
+++ b/webodf/tests/ops/TransformerTests.js
@@ -276,7 +276,3 @@ ops.TransformerTests.prototype.description = function () {
     "use strict";
     return "Test the transformations of ODT operations described in an XML file on resulting opspecs.";
 };
-(function () {
-    "use strict";
-    return ops.TransformerTests;
-}());


### PR DESCRIPTION
runtime.loadClass(...) no longer expects that eval(fileContent) yields the constructor, and a few loaded files rely on that (e.g. all singletons/namespaces), so let's be consistent and remove this now dead code.
