### PR TITLE
Only store the start node in DomUtils.getNodesInRange if within range

### DIFF
--- a/webodf/lib/core/DomUtils.js
+++ b/webodf/lib/core/DomUtils.js
@@ -444,16 +444,15 @@
                             currentNode = treeWalker.nextSibling();
                         }
                         break;
-                    case NodeFilter.FILTER_ACCEPT:
-                        // The first call to nextNode will return the next node *after* walker.currentNode
-                        // Therefore, need to manually check if currentNode should be included in the elements array
-                        // and save it if it passes the filter
-                        elements.push(currentNode);
+                    case NodeFilter.FILTER_SKIP:
+                        // Immediately advance to the next node without giving an opportunity for the current one to
+                        // be stored.
                         currentNode = treeWalker.nextNode();
                         break;
                     default:
-                    // case NodeFilter.FILTER_SKIP:
-                        currentNode = treeWalker.nextNode();
+                    // case NodeFilter.FILTER_ACCEPT:
+                        // Proceed into the following loop. The current node will be stored at the end of the loop
+                        // if it is contained within the requested range.
                         break;
                 }
 

--- a/webodf/tests/core/DomUtilsTests.js
+++ b/webodf/tests/core/DomUtilsTests.js
@@ -33,7 +33,7 @@
  * @source: http://www.webodf.org/
  * @source: https://github.com/kogmbh/WebODF/
  */
-/*global core, runtime, NodeFilter*/
+/*global core, runtime, NodeFilter, Node*/
 
 /**
  * @constructor
@@ -60,6 +60,10 @@ core.DomUtilsTests = function DomUtilsTests(runner) {
 
     function ignoreSpans(node) {
         return node.localName === "span" ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+    }
+
+    function textNodesOnly(node) {
+        return node.nodeType !== Node.TEXT_NODE ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
     }
 
     /**
@@ -639,6 +643,19 @@ core.DomUtilsTests = function DomUtilsTests(runner) {
         range.detach();
     }
 
+    function getNodesInRange_EndsInEmptyNode_ReturnsNothing() {
+        var range = document.createRange();
+        createNodes("<div>a</div><div></div>after");
+
+        range.setStart(t.doc.firstChild, t.doc.firstChild.childNodes.length);
+        range.setEnd(t.doc.childNodes[1], 0);
+
+        t.nodes = t.utils.getNodesInRange(range, textNodesOnly, NodeFilter.SHOW_ALL);
+
+        r.shouldBe(t, "t.nodes.shift()", "undefined");
+        range.detach();
+    }
+
     function mapObjOntoNode_EmptyObject() {
         t.node = document.createElement("span");
 
@@ -687,6 +704,7 @@ core.DomUtilsTests = function DomUtilsTests(runner) {
             getNodesInRange_NodeEndToNodeEnd_ReturnsBracketedNode,
             getNodesInRange_StartsOnRejectedNode_IgnoresChildNodes,
             getNodesInRange_StartsInRejectedNode_IgnoresChildNodes,
+            getNodesInRange_EndsInEmptyNode_ReturnsNothing,
 
             mapObjOntoNode_EmptyObject
         ]);


### PR DESCRIPTION
Fixes a regression introduced in 8b742ee. The currentNode was being incorrectly added to the results array before it was checked to see if it was contained inside the supplied range.
