### PR TITLE
Report the names of failing tests as well as the failed test count

### DIFF
--- a/webodf/lib/core/UnitTester.js
+++ b/webodf/lib/core/UnitTester.js
@@ -713,7 +713,7 @@ core.UnitTester = function UnitTester() {
     /**
      * @return {!number}
      **/
-    this.countFailedTests = function () {
+    this.failedTestsCount = function () {
         return failedTests;
     };
     /**

--- a/webodf/tests/tests.js
+++ b/webodf/tests/tests.js
@@ -246,10 +246,22 @@ if (!runtime.getWindow() || !runtime.getWindow().hasOwnProperty("use_karma")) {
     if (!runSelectedTests(selectedTests)) {
         runNextTest(tests, tester, function (tester) {
             "use strict";
+            var testResults = tester.results();
+
             //runtime.log(JSON.stringify(tester.results()));
-            runtime.log("Number of failed tests: " +
-                    String(tester.countFailedTests()));
-            runtime.exit(tester.countFailedTests());
+            runtime.log("Number of failed asserts: " + tester.failedTestsCount());
+            if (tester.failedTestsCount() !== 0) {
+                runtime.log("Failed tests:");
+                Object.keys(testResults).forEach(function (suiteName) {
+                    var suiteResults = testResults[suiteName];
+                    Object.keys(suiteResults).forEach(function(testName) {
+                        if (!suiteResults[testName]) {
+                            runtime.log(suiteName + "." + testName);
+                        }
+                    });
+                });
+            }
+            runtime.exit(tester.failedTestsCount());
             return;
         });
     }


### PR DESCRIPTION
Output from the headless Qt test runner is difficult to parse and generally flows off screen very quickly. Appending the failed test names makes it easier to troubleshoot which tests are problematic.
