### PR TITLE
Ensure a caret doesn't receive any new events after destroy is invoked

### DIFF
--- a/webodf/lib/core/ScheduledTask.js
+++ b/webodf/lib/core/ScheduledTask.js
@@ -40,7 +40,8 @@ core.ScheduledTask = function ScheduledTask(fn, scheduleTask, cancelTask) {
     "use strict";
     var timeoutId,
         scheduled = false,
-        args = [];
+        args = [],
+        destroyed = false;
 
     function cancel() {
         if (scheduled) {
@@ -60,6 +61,7 @@ core.ScheduledTask = function ScheduledTask(fn, scheduleTask, cancelTask) {
      * this call will have no impact
      */
     this.trigger = function () {
+        runtime.assert(destroyed === false, "Can't trigger destroyed ScheduledTask instance");
         args = Array.prototype.slice.call(arguments);
         if (!scheduled) {
             scheduled = true;
@@ -71,6 +73,7 @@ core.ScheduledTask = function ScheduledTask(fn, scheduleTask, cancelTask) {
      * Immediately trigger this task and clear any pending requests.
      */
     this.triggerImmediate = function () {
+        runtime.assert(destroyed === false, "Can't trigger destroyed ScheduledTask instance");
         args = Array.prototype.slice.call(arguments);
         execute();
     };
@@ -97,6 +100,7 @@ core.ScheduledTask = function ScheduledTask(fn, scheduleTask, cancelTask) {
      */
     this.destroy = function (callback) {
         cancel();
+        destroyed = true;
         callback();
     };
 

--- a/webodf/lib/gui/CaretManager.js
+++ b/webodf/lib/gui/CaretManager.js
@@ -67,13 +67,15 @@ gui.CaretManager = function CaretManager(sessionController) {
     function removeCaret(memberId) {
         var caret = carets[memberId];
         if (caret) {
-            /*jslint emptyblock:true*/
-            caret.destroy(function() {});
+            // Remove the caret before destroying it in case the destroy function causes new window/webodf events to be
+            // triggered. This ensures the caret can't receive any new events once destroy has been invoked
+            delete carets[memberId];
             if (memberId === sessionController.getInputMemberId()) {
                 sessionController.getEventManager().unsubscribe("compositionupdate", caret.handleUpdate);
             }
+            /*jslint emptyblock:true*/
+            caret.destroy(function() {});
             /*jslint emptyblock:false*/
-            delete carets[memberId];
         }
     }
 

--- a/webodf/lib/gui/EventManager.js
+++ b/webodf/lib/gui/EventManager.js
@@ -136,7 +136,11 @@ gui.EventManager = function EventManager(odtDocument) {
                 recentEvents.push(e); // Track this event as already processed by these handlers
                 if (self.filters.every(function (filter) { return filter(e); })) {
                     // Yes yes... this is not a spec-compliant event processor... sorry!
-                    subscribers.emit(eventName, e);
+                    try {
+                        subscribers.emit(eventName, e);
+                    } catch(/**@type{!Error}*/err) {
+                        runtime.log("Error occurred while processing " + eventName + ":\n" + err.message + "\n" + err.stack);
+                    }
                 }
                 // Reset the processed events list after this tick is complete. The event won't be
                 // processed by any other sources after this


### PR DESCRIPTION
Deleting the caret before calling ensures there is no way for any external sources to get access to the soon-to-be destroyed caret.

As part of tracking this down, scheduled tasks will now throw an error if an attempt is made to trigger the task (either delayed or immediate) after the particular instance has been destroyed.

This then showed that functions bound to browser events swallow errors quietly, so additional logging was added to the EventManager delegation code to ensure errors generated when processing an event are logged.
