### PR TITLE
Fix license header check not passing on Windows

### DIFF
--- a/webodf/tools/updateJS.js
+++ b/webodf/tools/updateJS.js
@@ -579,7 +579,7 @@ function Main(cmakeListPath) {
             licenses = {},
             // files for which the license is not checked
             licenseExceptions = ["lib/HeaderCompiled.js", "lib/core/JSLint.js",
-                "lib/core/RawDeflate.js", "lib/core/RawInflate.js"],
+                "lib/core/RawDeflate.js", "lib/core/RawInflate.js"].map(pathModule.normalize),
             commonLicense;
         // load JSLint
         /*jslint evil: true*/


### PR DESCRIPTION
In the recent change to check for the license headers during the build configuration the array of files excluded from this check were compared without accounting for the Windows backslash file separator. This was causing issues with the build so I have just changed this check to use normalized paths.
