### PR TITLE
Reset the cursor selection type back to text after adding an annotation

### DIFF
--- a/webodf/lib/ops/OpAddAnnotation.js
+++ b/webodf/lib/ops/OpAddAnnotation.js
@@ -168,6 +168,7 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
             paragraphElement = domUtils.getElementsByTagNameNS(annotation, odf.Namespaces.textns, "p")[0];
             selectedRange.selectNodeContents(paragraphElement);
             cursor.setSelectedRange(selectedRange, false);
+            cursor.setSelectionType(ops.OdtCursor.RangeSelection);
             odtDocument.emit(ops.Document.signalCursorMoved, cursor);
         }
         // Track this annotation


### PR DESCRIPTION
If an annotation is created while the user has selected an image, the selection type was not being correctly reset back to text range. This prevents the caret from displaying properly and disables typing commands.

Fixes #634.
