### PR TITLE
Fix karma.conf.js updating on Windows

### DIFF
--- a/webodf/tools/updateJS.js
+++ b/webodf/tools/updateJS.js
@@ -264,7 +264,7 @@ function Main(cmakeListPath) {
             if (err) {
                 throw err;
             }
-            var re = new RegExp("// MODULES\n[^!]+!");
+            var re = new RegExp("// MODULES\r?\n[^!]+!");
             content = content.replace(re,
                 "// MODULES\n            'lib/" +
                 modules.map(deNormalizePath)


### PR DESCRIPTION
Karma.conf.js may contain \r's when checked out on Windows. Cope with these when updating the karma configuration file content.
