### PR TITLE
Wait with sending statereadychange until all items from the load queue h...

### DIFF
--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1298,7 +1298,9 @@
                 handleAnnotations(odfnode);
 
                 if (!suppressEvent) {
-                    fireEvent("statereadychange", [odfcontainer]);
+                    loadingQueue.addToQueue(function () {
+                        fireEvent("statereadychange", [odfcontainer]);
+                    });
                 }
             }
 


### PR DESCRIPTION
...ave been handled.

Currently OdfCanvas sends statereadychange much too early for files with images or videos.
This patch puts the task to send statereadychange at the end of the queue.
