### PR TITLE
Fix font picker in Editor wrongly keeping fonts of old documents

### DIFF
--- a/programs/editor/widgets/fontPicker.js
+++ b/programs/editor/widgets/fontPicker.js
@@ -35,9 +35,7 @@ define("webodf/editor/widgets/fontPicker", [
             var self = this,
                 editorSession,
                 select,
-                editorFonts = [],
-                documentFonts = [],
-                selectionList = [];
+                documentFonts = [];
 
             select = new Select({
                 name: 'FontPicker',
@@ -79,8 +77,12 @@ define("webodf/editor/widgets/fontPicker", [
             this.onRemove = null;
 
             function populateFonts() {
-                var i, name, family;
-                editorFonts = editorSession ? editorSession.availableFonts : [];
+                var i,
+                    name,
+                    family,
+                    editorFonts = editorSession ? editorSession.availableFonts : [],
+                    selectionList = [];
+
                 documentFonts = editorSession ? editorSession.getDeclaredFonts() : [];
 
                 // First populate the fonts used in the document


### PR DESCRIPTION
Reason was that selectionList was not cleared on next call of  populateFonts()...

Fixes #639
