### PR TITLE
Group up style information changes and report at the end of an op batch

### DIFF
--- a/webodf/lib/core/LazyProperty.js
+++ b/webodf/lib/core/LazyProperty.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2010-2014 KO GmbH <copyright@kogmbh.com>
+ *
+ * @licstart
+ * This file is part of WebODF.
+ *
+ * WebODF is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License (GNU AGPL)
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * WebODF is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
+ * @licend
+ *
+ * @source: http://www.webodf.org/
+ * @source: https://github.com/kogmbh/WebODF/
+ */
+
+/*global core*/
+
+// TODO Apparently newer closure compilers do a better job with generics
+
+/**
+ * Lazily loaded property. The value is loaded using the valueLoader and cached
+ * the first time it's requested. Subsequent requests will return the cached value.
+ * Calling reset will clear the cached value, causing the next value request
+ * to load a new value via the valueLoader.
+ *
+ * @constructor
+ * @template T
+ * @param {!function():Object} valueLoader Property value loader
+ */
+core.LazyProperty = function (valueLoader) {
+    "use strict";
+    var cachedValue,
+        valueLoaded = false;
+
+    /**
+     * @return {T}
+     */
+    this.value = function() {
+        if (!valueLoaded) {
+            cachedValue = valueLoader();
+            valueLoaded = true;
+        }
+        return cachedValue;
+    };
+
+    /**
+     * @return {undefined}
+     */
+    this.reset = function() {
+        valueLoaded = false;
+    };
+};

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -18,6 +18,8 @@
     ],
     "core.EventNotifier": [
     ],
+    "core.LazyProperty": [
+    ],
     "core.LoopWatchDog": [
     ],
     "core.PositionFilter": [
@@ -81,6 +83,7 @@
     "gui.CommonConstraints": [
     ],
     "gui.DirectFormattingController": [
+        "core.LazyProperty",
         "gui.CommonConstraints",
         "gui.SessionConstraints",
         "gui.SessionContext",

--- a/webodf/tools/karma.conf.js
+++ b/webodf/tools/karma.conf.js
@@ -29,6 +29,7 @@ module.exports = function (config) {
             'lib/core/Cursor.js',
             'lib/core/Destroyable.js',
             'lib/core/EventNotifier.js',
+            'lib/core/LazyProperty.js',
             'lib/core/LoopWatchDog.js',
             'lib/core/PositionIterator.js',
             'lib/core/PositionFilter.js',


### PR DESCRIPTION
Operation batches that modify a large number of paragraphs (or repeatedly modify the same paragraph) can cause numerous unnecessary style change events to be triggered. Rather than reporting these instantly, track them as they occur and emit the style change summary on batch end.

Related to #610.
