### PR TITLE
Disable hyperlink editor for the upcoming release

### DIFF
--- a/programs/editor/Editor.js
+++ b/programs/editor/Editor.js
@@ -586,7 +586,8 @@ define("webodf/editor/Editor", [
                     paragraphStyleSelectingEnabled = isEnabled(args.paragraphStyleSelectingEnabled),
                     paragraphStyleEditingEnabled = isEnabled(args.paragraphStyleEditingEnabled),
                     imageEditingEnabled = isEnabled(args.imageEditingEnabled, FEATURE.COLLAB_UNSTABLE),
-                    hyperlinkEditingEnabled = isEnabled(args.hyperlinkEditingEnabled, FEATURE.COLLAB_UNSTABLE),
+                    // TODO: temporarily disabled because of at least the issues #490 and #650 (see github issue tracker)
+                    hyperlinkEditingEnabled = false, // isEnabled(args.hyperlinkEditingEnabled, FEATURE.COLLAB_UNSTABLE),
                     reviewModeEnabled = isEnabled(args.reviewModeEnabled, FEATURE.COLLAB_UNSTABLE),
                     // annotations not yet properly supported for OT
                     annotationsEnabled = reviewModeEnabled || isEnabled(args.annotationsEnabled, FEATURE.COLLAB_UNSTABLE),

--- a/programs/editor/localeditor.js
+++ b/programs/editor/localeditor.js
@@ -190,7 +190,6 @@ var webodfEditor = (function () {
         if (args.reviewModeEnabled === true) {
             editorOptions.reviewModeEnabled = true;
             editorOptions.directParagraphStylingEnabled = false;
-            editorOptions.hyperlinkEditingEnabled = false;
             editorOptions.imageEditingEnabled = false;
             editorOptions.paragraphStyleSelectingEnabled = false;
             editorOptions.paragraphStyleEditingEnabled = false;

--- a/webodf/lib/gui/HyperlinkController.js
+++ b/webodf/lib/gui/HyperlinkController.js
@@ -25,6 +25,7 @@
 /*global runtime, core, gui, Node, ops, odf */
 
 /**
+ * WARNING: do not use, currently there are at least the issues #490 and #650 (see github issue tracker)
  * @constructor
  * @implements {core.Destroyable}
  * @param {!ops.Session} session


### PR DESCRIPTION
Done by simply hiding it in the UI and in the Editor API/usage samples

Solves #653
