### PR TITLE
Fix style buttons' behavior when selecting the two positions around an annotation

### DIFF
--- a/programs/editor/widgets/paragraphAlignment.js
+++ b/programs/editor/widgets/paragraphAlignment.js
@@ -152,9 +152,9 @@ define("webodf/editor/widgets/paragraphAlignment", [
                 });
             }
 
-            function enableStyleButtons(isEnabled) {
+            function enableStyleButtons(enabledFeatures) {
                 widget.children.forEach(function (element) {
-                    element.setAttribute('disabled', !isEnabled.directParagraphStyling);
+                    element.setAttribute('disabled', !enabledFeatures.directParagraphStyling);
                 });
             }
 
@@ -171,7 +171,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
                     directFormattingController.subscribe(gui.DirectFormattingController.enabledChanged, enableStyleButtons);
 
                     if(directFormattingController) {
-                        enableStyleButtons(directFormattingController.isEnabled());
+                        enableStyleButtons(directFormattingController.enabledFeatures());
                     }
                 }
 

--- a/programs/editor/widgets/simpleStyles.js
+++ b/programs/editor/widgets/simpleStyles.js
@@ -161,14 +161,14 @@ define("webodf/editor/widgets/simpleStyles", [
                 });
             }
 
-            function enableStyleButtons(isEnabled) {
+            function enableStyleButtons(enabledFeatures) {
                 widget.children.forEach(function (element) {
-                    element.setAttribute('disabled', !isEnabled.directTextStyling);
+                    element.setAttribute('disabled', !enabledFeatures.directTextStyling);
                 });
             }
 
             function handleCursorMoved(cursor) {
-                if (directFormattingController.isEnabled().directTextStyling) {
+                if (directFormattingController.enabledFeatures().directTextStyling) {
                     var disabled = cursor.getSelectionType() === ops.OdtCursor.RegionSelection;
                     enableStyleButtons({ directTextStyling: !disabled });
                 }
@@ -190,7 +190,7 @@ define("webodf/editor/widgets/simpleStyles", [
                     directFormattingController.subscribe(gui.DirectFormattingController.enabledChanged, enableStyleButtons);
 
                     if (directFormattingController) {
-                        enableStyleButtons(directFormattingController.isEnabled());
+                        enableStyleButtons(directFormattingController.enabledFeatures());
                     }
                 }
 

--- a/webodf/lib/gui/DirectFormattingController.js
+++ b/webodf/lib/gui/DirectFormattingController.js
@@ -67,7 +67,7 @@ gui.DirectFormattingController = function DirectFormattingController(
         /**@type {!core.LazyProperty.<!{containsText: !boolean, appliedStyles: !Array.<!Object>, styleSummary: !gui.StyleSummary}>} */
         selectionInfoCache,
         /**@type {!{directTextStyling: !boolean, directParagraphStyling: !boolean}}*/
-        isEnabled = {
+        enabledFeatures = {
             directTextStyling: false,
             directParagraphStyling: false
         };
@@ -188,30 +188,31 @@ gui.DirectFormattingController = function DirectFormattingController(
      * @return {undefined}
      */
     function updateEnabledState() {
-        var newIsEnabled = {
+        var newEnabledFeatures = {
             directTextStyling: true,
             directParagraphStyling: true
         };
 
         if (sessionConstraints.getState(gui.CommonConstraints.EDIT.REVIEW_MODE) === true) {
-            newIsEnabled.directTextStyling = newIsEnabled.directParagraphStyling = /**@type{!boolean}*/(sessionContext.isLocalCursorWithinOwnAnnotation());
+            newEnabledFeatures.directTextStyling = newEnabledFeatures.directParagraphStyling = /**@type{!boolean}*/(sessionContext.isLocalCursorWithinOwnAnnotation());
         }
 
-        if (newIsEnabled.directTextStyling) {
-            newIsEnabled.directTextStyling = selectionInfoCache.value().containsText;
+        if (newEnabledFeatures.directTextStyling) {
+            newEnabledFeatures.directTextStyling = selectionInfoCache.value().containsText;
         }
 
-        if (newIsEnabled !== isEnabled) {
-            isEnabled = newIsEnabled;
-            eventNotifier.emit(gui.DirectFormattingController.enabledChanged, isEnabled);
+        if (!(newEnabledFeatures.directTextStyling === enabledFeatures.directTextStyling
+                && newEnabledFeatures.directParagraphStyling === enabledFeatures.directParagraphStyling)) {
+            enabledFeatures = newEnabledFeatures;
+            eventNotifier.emit(gui.DirectFormattingController.enabledChanged, enabledFeatures);
         }
     }
 
     /**
      * @return {!{directTextStyling: !boolean, directParagraphStyling: !boolean}}
      */
-    this.isEnabled = function () {
-        return isEnabled;
+    this.enabledFeatures = function () {
+        return enabledFeatures;
     };
 
     /**
@@ -265,7 +266,7 @@ gui.DirectFormattingController = function DirectFormattingController(
      * @return {undefined}
      */
     function formatTextSelection(textProperties) {
-        if (!isEnabled.directTextStyling) {
+        if (!enabledFeatures.directTextStyling) {
             return;
         }
 
@@ -529,7 +530,7 @@ gui.DirectFormattingController = function DirectFormattingController(
      * @return {undefined}
      */
     function applyParagraphDirectStyling(applyDirectStyling) {
-        if (!isEnabled.directParagraphStyling) {
+        if (!enabledFeatures.directParagraphStyling) {
             return;
         }
 
@@ -737,7 +738,7 @@ gui.DirectFormattingController = function DirectFormattingController(
      * @return {!Array.<!ops.Operation>}
      */
     this.createParagraphStyleOps = function (position) {
-        if (!isEnabled.directParagraphStyling) {
+        if (!enabledFeatures.directParagraphStyling) {
             return [];
         }
 


### PR DESCRIPTION
This patch makes the selection info caching logic also save the information for selections which contain no text elements, i.e. of the kind in #560. This gets rid of the annoying all-buttons-activated behavior.

Next, for sensible editing, direct text styling is disabled for such selections, while direct paragraph styling is left enabled.

The widgets are accordingly subscribed to these states.
