### PR TITLE
Ensure various places always have a valid root element

### DIFF
--- a/webodf/lib/gui/SelectionController.js
+++ b/webodf/lib/gui/SelectionController.js
@@ -63,7 +63,7 @@ gui.SelectionController = function SelectionController(session, inputMemberId) {
      */
     function createWordBoundaryStepIterator(node, offset, includeWhitespace) {
         var wordBoundaryFilter = new odf.WordBoundaryFilter(odtDocument, includeWhitespace),
-            nodeRoot = odtDocument.getRootElement(node),
+            nodeRoot = odtDocument.getRootElement(node) || odtDocument.getRootNode(),
             nodeRootFilter = odtDocument.createRootFilter(nodeRoot);
         return odtDocument.createStepIterator(node, offset, [baseFilter, nodeRootFilter, wordBoundaryFilter], nodeRoot);
     }

--- a/webodf/lib/gui/SessionController.js
+++ b/webodf/lib/gui/SessionController.js
@@ -455,11 +455,13 @@ gui.SessionControllerOptions = function () {
          */
         function handleMouseDown(e) {
             var target = getTarget(e),
-                cursor = odtDocument.getCursor(inputMemberId);
+                cursor = odtDocument.getCursor(inputMemberId),
+                rootNode;
             clickStartedWithinCanvas = target !== null && domUtils.containsNode(odtDocument.getOdfCanvas().getElement(), target);
             if (clickStartedWithinCanvas) {
                 isMouseMoved = false;
-                mouseDownRootFilter = odtDocument.createRootFilter(/**@type{!Node}*/(target));
+                rootNode = odtDocument.getRootElement(/**@type{!Node}*/(target)) || odtDocument.getRootNode();
+                mouseDownRootFilter = odtDocument.createRootFilter(rootNode);
                 clickCount = computeClickCount(e);
                 if (cursor && e.shiftKey) {
                     // Firefox seems to get rather confused about the window selection when shift+extending it.


### PR DESCRIPTION
There is a small edge between the canvas border and the office:text element that the user can click in. Doing this returns null for the root element (as it is the container that contains the office:text element), causing an unhandled null reference exception to occur in some circumstances.

Fixes #664.
