### PR TITLE
Improve viewer license attribution

### DIFF
--- a/programs/viewer/index.html
+++ b/programs/viewer/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <!--
-  Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+  Copyright (C) 2012-2014 KO GmbH <copyright@kogmbh.com>
 
   @licstart
   This file is part of WebODF.

--- a/programs/viewer/viewer.css
+++ b/programs/viewer/viewer.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2014 KO GmbH <copyright@kogmbh.com>
+ * Copyright (C) 2012-2014 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
  * This file is part of WebODF.

--- a/programs/viewer/viewer.js
+++ b/programs/viewer/viewer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+ * Copyright (C) 2012-2014 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
  * This file is part of WebODF.


### PR DESCRIPTION
Previously the only attribution was in a README.

This re-adds the original license headers alongside the license for WebODF, with a comment describing that it is a derivative.

Also fixes the copyright year range for the WebODF headers.
