### PR TITLE
Added type information to applied styles calculation

### DIFF
--- a/webodf/lib/gui/DirectFormattingController.js
+++ b/webodf/lib/gui/DirectFormattingController.js
@@ -714,8 +714,8 @@ gui.DirectFormattingController = function DirectFormattingController(
      */
     function isTextStyleDifferentFromFirstParagraph(range, paragraphNode) {
         var textNodes = getNodes(range),
-            textStyle = odtDocument.getFormatting().getAppliedStyles(textNodes)[0],
-            paragraphStyle = odtDocument.getFormatting().getAppliedStylesForElement(paragraphNode);
+            textStyle = odtDocument.getFormatting().getAppliedStyles(textNodes)[0].styleProperties,
+            paragraphStyle = odtDocument.getFormatting().getAppliedStylesForElement(paragraphNode).styleProperties;
         if (!textStyle || textStyle['style:family'] !== 'text' || !textStyle['style:text-properties']) {
             return false;
         }

--- a/webodf/lib/gui/StyleSummary.js
+++ b/webodf/lib/gui/StyleSummary.js
@@ -26,8 +26,7 @@
 
 /**
  * @constructor
- * @param {!Array.<!Object.<!string, !Object.<!string, !Object>>>} styles Array of style
- *  objects as returned from Formatting.getAppliedStyles
+ * @param {!Array.<!odf.Formatting.AppliedStyle>} styles
  */
 gui.StyleSummary = function StyleSummary(styles) {
     "use strict";
@@ -49,7 +48,7 @@ gui.StyleSummary = function StyleSummary(styles) {
         if (!propertyValues.hasOwnProperty(cacheKey)) {
             values = [];
             styles.forEach(function (style) {
-                var styleSection = style[section],
+                var styleSection = /**@type{!Object.<!string, !string>}*/(style.styleProperties[section]),
                     value = styleSection && styleSection[propertyName];
                 if (values.indexOf(value) === -1) {
                     values.push(value);

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -188,6 +188,7 @@
         "ops.OdtCursor"
     ],
     "gui.StyleSummary": [
+        "odf.Formatting"
     ],
     "gui.SvgSelectionView": [
         "core.Async",

--- a/webodf/lib/odf/TextStyleApplicator.js
+++ b/webodf/lib/odf/TextStyleApplicator.js
@@ -70,7 +70,7 @@ odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, form
          */
         this.isStyleApplied = function (textNode) {
             // TODO can direct style to element just be removed somewhere to end up with desired style?
-            var appliedStyle = formatting.getAppliedStylesForElement(textNode, cachedAppliedStyles);
+            var appliedStyle = formatting.getAppliedStylesForElement(textNode, cachedAppliedStyles).styleProperties;
             return compare(info, appliedStyle);
         };
     }

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -432,7 +432,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
 
     /**
      * @param {!string} styleName
-     * @return {?Object}
+     * @return {?odf.Formatting.StyleData}
      */
     function getParagraphStyleAttributes(styleName) {
         var node = getParagraphStyleElement(styleName);

--- a/webodf/tests/odf/FormattingTests.js
+++ b/webodf/tests/odf/FormattingTests.js
@@ -330,7 +330,7 @@ odf.FormattingTests = function FormattingTests(runner) {
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.length", "2");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'S1', displayName: 'S1 Display', family: 'text', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
     }
     function getAppliedStyles_NestedHierarchy() {
         t.doc = createDocument("<text:p text:style-name='P1'><text:span text:style-name='S1'><text:span text:style-name='SBold'>A</text:span></text:span></text:p>");
@@ -342,7 +342,7 @@ odf.FormattingTests = function FormattingTests(runner) {
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'SBold', displayName: 'SBold Display', family: 'text', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'S1', displayName: 'S1 Display', family: 'text', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'S1 Font', 'fo:font-weight': 'bold'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'S1 Font', 'fo:font-weight': 'bold'})");
     }
     function getAppliedStyles_CompleteContent_OnlyReportsUniqueStyles() {
         t.doc = createDocument("<text:p text:style-name='P1'>A<text:span text:style-name='S1'>B</text:span>C</text:p>");
@@ -353,14 +353,14 @@ odf.FormattingTests = function FormattingTests(runner) {
 
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.length", "1");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'P1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'P1 Font'})");
 
         t.appliedStyles.shift();
 
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.length", "2");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'S1', displayName: 'S1 Display', family: 'text', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
     }
     function getAppliedStyles_EmptyArray() {
         t.appliedStyles = t.formatting.getAppliedStyles([]);
@@ -376,7 +376,7 @@ odf.FormattingTests = function FormattingTests(runner) {
 
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.length", "1");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'P1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'P1 Font'})");
     }
     function getAppliedStyles_StartsAndEnds_InDifferentTextNodes() {
         t.doc = createDocument("<text:p text:style-name='P1'>A<text:span text:style-name='S1'>B</text:span>C</text:p>");
@@ -387,14 +387,14 @@ odf.FormattingTests = function FormattingTests(runner) {
 
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.length", "1");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'P1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'P1 Font'})");
 
         t.appliedStyles.shift();
 
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.length", "2");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'S1', displayName: 'S1 Display', family: 'text', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
     }
     function getAppliedStyles_SimpleList() {
         var xml = "<text:list text:style-name='L2'><text:list-item>" +
@@ -409,7 +409,7 @@ odf.FormattingTests = function FormattingTests(runner) {
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'S1', displayName: 'S1 Display', family: 'text', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'L2', displayName: 'L2 Display', family: 'list-style', isCommonStyle: false})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
     }
     function getAppliedStyles_NestedList() {
         var xml = "<text:list text:style-name='L1'><text:list-item>" +
@@ -427,7 +427,7 @@ odf.FormattingTests = function FormattingTests(runner) {
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'P1', displayName: 'P1 Display', family: 'paragraph', isCommonStyle: true})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'L2', displayName: 'L2 Display', family: 'list-style', isCommonStyle: false})");
         r.shouldBe(t, "t.appliedStyles[0].orderedStyles.shift()", "({name: 'L1', displayName: 'L1 Display', family: 'list-style', isCommonStyle: false})");
-        r.shouldBe(t, "t.appliedStyles[0]['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
+        r.shouldBe(t, "t.appliedStyles[0].styleProperties['style:text-properties']", "({'fo:font-name': 'S1 Font'})");
     }
     function getAppliedStyles_InvalidNodes() {
         var i, node,


### PR DESCRIPTION
The existing applied styles calculation returns an object structure with incomplete type information for Closure Compiler causing it to complain when trying to access parts of the returned object like the ordered styles collection.

To remedy this I have added some typedefs that describe the objects returned from the applied styles calculations. To add type annotations in a clean way I changed the structure of the object returned from the applied styles calculation.
