### PR TITLE
Make Java a required dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ else ()
 endif ()
 
 # java runtime is needed for Closure Compiler
-find_package(Java COMPONENTS Runtime)
+find_package(Java COMPONENTS Runtime REQUIRED)
 
 # Node.js will be downloaded on Windows systems, so check for installed version is below
 SET(REQUIRED_NODEJS_VERSION 0.10.5)
@@ -92,33 +92,29 @@ else ( IS_DIRECTORY $ENV{WEBODF_DOWNLOAD_DIR} )
 endif ( IS_DIRECTORY $ENV{WEBODF_DOWNLOAD_DIR} )
 MESSAGE ( STATUS "external downloads will be stored/expected in: ${EXTERNALS_DOWNLOAD_DIR}" )
 
-if(Java_JAVA_EXECUTABLE)
-    # Closure Compiler
-    ExternalProject_Add(
-        ClosureCompiler
-        DOWNLOAD_DIR ${EXTERNALS_DOWNLOAD_DIR}
-        URL "http://dl.google.com/closure-compiler/compiler-20130823.tar.gz"
-        URL_MD5 105db24c4676e23f2495adfdea3159bc
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND ""
-    )
-    set(CLOSURE_JAR ${CMAKE_BINARY_DIR}/ClosureCompiler-prefix/src/ClosureCompiler/compiler.jar)
-endif(Java_JAVA_EXECUTABLE)
+# Closure Compiler
+ExternalProject_Add(
+    ClosureCompiler
+    DOWNLOAD_DIR ${EXTERNALS_DOWNLOAD_DIR}
+    URL "http://dl.google.com/closure-compiler/compiler-20130823.tar.gz"
+    URL_MD5 105db24c4676e23f2495adfdea3159bc
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+)
+set(CLOSURE_JAR ${CMAKE_BINARY_DIR}/ClosureCompiler-prefix/src/ClosureCompiler/compiler.jar)
 
 # Rhino
-if(Java_JAVA_EXECUTABLE)
-    ExternalProject_Add(
-        Rhino
-        DOWNLOAD_DIR ${EXTERNALS_DOWNLOAD_DIR}
-        URL "http://ftp.mozilla.org/pub/js/rhino1_7R3.zip"
-        URL_MD5 99d94103662a8d0b571e247a77432ac5
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ""
-        INSTALL_COMMAND ""
-    )
-    set(RHINO ${CMAKE_BINARY_DIR}/Rhino-prefix/src/Rhino/js.jar)
-endif(Java_JAVA_EXECUTABLE)
+ExternalProject_Add(
+    Rhino
+    DOWNLOAD_DIR ${EXTERNALS_DOWNLOAD_DIR}
+    URL "http://ftp.mozilla.org/pub/js/rhino1_7R3.zip"
+    URL_MD5 99d94103662a8d0b571e247a77432ac5
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+)
+set(RHINO ${CMAKE_BINARY_DIR}/Rhino-prefix/src/Rhino/js.jar)
 
 # JSDoc
 ExternalProject_Add(

--- a/programs/editor/CMakeLists.txt
+++ b/programs/editor/CMakeLists.txt
@@ -149,24 +149,18 @@ endforeach(AE_FILE)
 
 add_custom_target(wodotexteditorbuilddir-target DEPENDS ${WODOTEXTEDITORBUILDDIR} ${WODOTEXTEDITOR_BUILDFILES})
 
-if (Java_JAVA_EXECUTABLE)
-  set(WODOTEXTEDITORDOC_BUILDDIR ${WODOTEXTEDITORBUILDDIR}/docs)
-  add_custom_command(
-       OUTPUT ${WODOTEXTEDITORDOC_BUILDDIR}/index.html
-       COMMAND ${Java_JAVA_EXECUTABLE} ARGS -jar ${JSDOCDIR}/jsrun.jar
-          ${JSDOCDIR}/app/run.js
-          -d=${WODOTEXTEDITORDOC_BUILDDIR}
-          -t=${JSDOCDIR}/templates/jsdoc
-          ${WODOTEXTEDITORBUILDDIR}/wodotexteditor.js
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS wodotexteditorbuilddir-target JsDoc
-  )
-  add_custom_target(wodotexteditor-doc DEPENDS ${WODOTEXTEDITORDOC_BUILDDIR}/index.html)
-else (Java_JAVA_EXECUTABLE)
-    # TODO: create a proper dummy target, though ideally this would be a warning that the docs will be missing, perhaps should even fail
-#   add_custom_target(doc DEPENDS ${WODOTEXTEDITORBUILDDIR}/docs/index.html)
-endif (Java_JAVA_EXECUTABLE)
-
+set(WODOTEXTEDITORDOC_BUILDDIR ${WODOTEXTEDITORBUILDDIR}/docs)
+add_custom_command(
+    OUTPUT ${WODOTEXTEDITORDOC_BUILDDIR}/index.html
+    COMMAND ${Java_JAVA_EXECUTABLE} ARGS -jar ${JSDOCDIR}/jsrun.jar
+        ${JSDOCDIR}/app/run.js
+        -d=${WODOTEXTEDITORDOC_BUILDDIR}
+        -t=${JSDOCDIR}/templates/jsdoc
+        ${WODOTEXTEDITORBUILDDIR}/wodotexteditor.js
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS wodotexteditorbuilddir-target JsDoc
+)
+add_custom_target(wodotexteditor-doc DEPENDS ${WODOTEXTEDITORDOC_BUILDDIR}/index.html)
 
 # package wodotexteditor
 set(WODOTEXTEDITOR_ZIP wodotexteditor-${WEBODF_VERSION}.zip)

--- a/webodf/CMakeLists.txt
+++ b/webodf/CMakeLists.txt
@@ -65,140 +65,137 @@ add_custom_command(
 )
 add_custom_target(webodf.css.js-target DEPENDS webodf.css.js)
 
-if (Java_JAVA_EXECUTABLE)
-  # Windows has a command-line limit of around 8,000 chars, so files to be compiled are supplied to CC using the --flagfile
-  # option to help keep the length of the compilation command as small as possible.
-  file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt "--warning_level VERBOSE --jscomp_error accessControls --jscomp_error ambiguousFunctionDecl --jscomp_error checkEventfulObjectDisposal --jscomp_error checkRegExp --jscomp_error checkStructDictInheritance --jscomp_error checkTypes --jscomp_error checkVars --jscomp_error const --jscomp_error constantProperty --jscomp_error deprecated --jscomp_error duplicateMessage --jscomp_error es3 --jscomp_error es5Strict --jscomp_error externsValidation --jscomp_error fileoverviewTags --jscomp_error globalThis --jscomp_error invalidCasts --jscomp_error misplacedTypeAnnotation --jscomp_error missingProperties --jscomp_error missingProvide --jscomp_error missingRequire --jscomp_error missingReturn --jscomp_off nonStandardJsDocs --jscomp_error suspiciousCode --jscomp_error strictModuleDepCheck --jscomp_error typeInvalidation --jscomp_error undefinedNames --jscomp_error undefinedVars --jscomp_error unknownDefines --jscomp_error uselessCode --jscomp_error visibility --summary_detail_level 3")
+# Windows has a command-line limit of around 8,000 chars, so files to be compiled are supplied to CC using the --flagfile
+# option to help keep the length of the compilation command as small as possible.
+file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt "--warning_level VERBOSE --jscomp_error accessControls --jscomp_error ambiguousFunctionDecl --jscomp_error checkEventfulObjectDisposal --jscomp_error checkRegExp --jscomp_error checkStructDictInheritance --jscomp_error checkTypes --jscomp_error checkVars --jscomp_error const --jscomp_error constantProperty --jscomp_error deprecated --jscomp_error duplicateMessage --jscomp_error es3 --jscomp_error es5Strict --jscomp_error externsValidation --jscomp_error fileoverviewTags --jscomp_error globalThis --jscomp_error invalidCasts --jscomp_error misplacedTypeAnnotation --jscomp_error missingProperties --jscomp_error missingProvide --jscomp_error missingRequire --jscomp_error missingReturn --jscomp_off nonStandardJsDocs --jscomp_error suspiciousCode --jscomp_error strictModuleDepCheck --jscomp_error typeInvalidation --jscomp_error undefinedNames --jscomp_error undefinedVars --jscomp_error unknownDefines --jscomp_error uselessCode --jscomp_error visibility --summary_detail_level 3")
 
-  file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${HEADERCOMPILED_FILE}")
+file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${HEADERCOMPILED_FILE}")
 
-  foreach(JSFILE ${LIBJSFILES})
+foreach(JSFILE ${LIBJSFILES})
     if (IS_ABSOLUTE ${JSFILE})
-      file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${JSFILE}")
+        file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${JSFILE}")
     else (IS_ABSOLUTE ${JSFILE})
-      file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${CMAKE_CURRENT_SOURCE_DIR}/${JSFILE}")
+        file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${CMAKE_CURRENT_SOURCE_DIR}/${JSFILE}")
     endif (IS_ABSOLUTE ${JSFILE})
-  endforeach(JSFILE ${LIBJSFILES})
+endforeach(JSFILE ${LIBJSFILES})
 
-  file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${CMAKE_CURRENT_BINARY_DIR}/webodf.css.js")
+file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt " --js ${CMAKE_CURRENT_BINARY_DIR}/webodf.css.js")
 
-  # copy the flagfile for some targets which require the test files to be passed into CC
-  # this requires a separate file as other targets don't want to compile the test files
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt)
+# copy the flagfile for some targets which require the test files to be passed into CC
+# this requires a separate file as other targets don't want to compile the test files
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt)
 
-  foreach(JSFILE ${TESTJSFILES})
+foreach(JSFILE ${TESTJSFILES})
     file (APPEND ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt " --js ${CMAKE_CURRENT_SOURCE_DIR}/${JSFILE}")
-  endforeach(JSFILE ${TESTJSFILES})
+endforeach(JSFILE ${TESTJSFILES})
 
-  # nonStandardJsDocs is not used because we use @licstart @licend and @source
-  # ideally we would enable --jscomp_error reportUnknownTypes
-  # -XX:+TieredCompilation reduces compilation time by about 30%
-  set(SHARED_CLOSURE_ARGS -XX:+TieredCompilation -jar ${CLOSURE_JAR})
+# nonStandardJsDocs is not used because we use @licstart @licend and @source
+# ideally we would enable --jscomp_error reportUnknownTypes
+# -XX:+TieredCompilation reduces compilation time by about 30%
+set(SHARED_CLOSURE_ARGS -XX:+TieredCompilation -jar ${CLOSURE_JAR})
 
-  add_custom_command(
-      OUTPUT simplecompiled.js
-      COMMAND ${Java_JAVA_EXECUTABLE}
-      ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt
-         --compilation_level WHITESPACE_ONLY
-         --formatting PRETTY_PRINT
-         --js_output_file simplecompiled.js-
-      # in WHITESPACE_ONLY mode, it is not possible to define IS_COMPILED_CODE
-      # so the value for IS_COMPILED_CODE is set by find and replace in the code
-      COMMAND ${CMAKE_COMMAND} -DFILENAME:STRING="${CMAKE_CURRENT_BINARY_DIR}/simplecompiled.js" -P ${CMAKE_CURRENT_SOURCE_DIR}/tools/set_IS_COMPILED_CODE.cmake
-      DEPENDS ClosureCompiler ${LIBJSFILES} ${TESTJSFILES}
-        ${CMAKE_CURRENT_BINARY_DIR}/webodf.css.js
-  )
-  add_custom_target(simplecompiled.js-target DEPENDS simplecompiled.js)
+add_custom_command(
+    OUTPUT simplecompiled.js
+    COMMAND ${Java_JAVA_EXECUTABLE}
+    ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt
+        --compilation_level WHITESPACE_ONLY
+        --formatting PRETTY_PRINT
+        --js_output_file simplecompiled.js-
+    # in WHITESPACE_ONLY mode, it is not possible to define IS_COMPILED_CODE
+    # so the value for IS_COMPILED_CODE is set by find and replace in the code
+    COMMAND ${CMAKE_COMMAND} -DFILENAME:STRING="${CMAKE_CURRENT_BINARY_DIR}/simplecompiled.js" -P ${CMAKE_CURRENT_SOURCE_DIR}/tools/set_IS_COMPILED_CODE.cmake
+    DEPENDS ClosureCompiler ${LIBJSFILES} ${TESTJSFILES}
+    ${CMAKE_CURRENT_BINARY_DIR}/webodf.css.js
+)
+add_custom_target(simplecompiled.js-target DEPENDS simplecompiled.js)
 
-  add_custom_command(
-      OUTPUT compiled.js
-      COMMAND ${Java_JAVA_EXECUTABLE}
-      ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt
-         --define IS_COMPILED_CODE=true
-         --compilation_level ADVANCED_OPTIMIZATIONS
-         --formatting PRETTY_PRINT
-         --externs ${CMAKE_CURRENT_SOURCE_DIR}/tools/externs.js
-         --js_output_file compiled.js-
-      COMMAND ${CMAKE_COMMAND} ARGS -E rename compiled.js- compiled.js
-      DEPENDS ClosureCompiler ${LIBJSFILES} ${TESTJSFILES} tools/externs.js
-          webodf.css.js-target
-  )
-  add_custom_target(compiled.js-target DEPENDS compiled.js)
+add_custom_command(
+    OUTPUT compiled.js
+    COMMAND ${Java_JAVA_EXECUTABLE}
+    ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-withTestFiles.txt
+        --define IS_COMPILED_CODE=true
+        --compilation_level ADVANCED_OPTIMIZATIONS
+        --formatting PRETTY_PRINT
+        --externs ${CMAKE_CURRENT_SOURCE_DIR}/tools/externs.js
+        --js_output_file compiled.js-
+    COMMAND ${CMAKE_COMMAND} ARGS -E rename compiled.js- compiled.js
+    DEPENDS ClosureCompiler ${LIBJSFILES} ${TESTJSFILES} tools/externs.js
+        webodf.css.js-target
+)
+add_custom_target(compiled.js-target DEPENDS compiled.js)
 
-  add_custom_command(
-      OUTPUT webodf.js
-      COMMAND ${Java_JAVA_EXECUTABLE}
-      ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt
-         --jscomp_error reportUnknownTypes
-         --define IS_COMPILED_CODE=true
-         --compilation_level SIMPLE_OPTIMIZATIONS
-         --externs ${CMAKE_CURRENT_SOURCE_DIR}/tools/externs.js
-         --js_output_file webodf.js-
-      COMMAND ${CMAKE_COMMAND} ARGS -E rename webodf.js- webodf.js
-      DEPENDS ClosureCompiler ${LIBJSFILES} tools/externs.js
-         webodf.css.js-target ${HEADERCOMPILED_FILE}
-  )
-  add_custom_target(webodf.js-target DEPENDS webodf.js)
+add_custom_command(
+    OUTPUT webodf.js
+    COMMAND ${Java_JAVA_EXECUTABLE}
+    ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt
+        --jscomp_error reportUnknownTypes
+        --define IS_COMPILED_CODE=true
+        --compilation_level SIMPLE_OPTIMIZATIONS
+        --externs ${CMAKE_CURRENT_SOURCE_DIR}/tools/externs.js
+        --js_output_file webodf.js-
+    COMMAND ${CMAKE_COMMAND} ARGS -E rename webodf.js- webodf.js
+    DEPENDS ClosureCompiler ${LIBJSFILES} tools/externs.js
+        webodf.css.js-target ${HEADERCOMPILED_FILE}
+)
+add_custom_target(webodf.js-target DEPENDS webodf.js)
 
-  add_custom_command(
-      OUTPUT webodf-debug.js
-      COMMAND ${Java_JAVA_EXECUTABLE}
-      ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt
-         --jscomp_error reportUnknownTypes
-         --define IS_COMPILED_CODE=true
-         --compilation_level WHITESPACE_ONLY
-         --formatting PRETTY_PRINT
-         --externs ${CMAKE_CURRENT_SOURCE_DIR}/tools/externs.js
-         --js_output_file webodf-debug.js-
-      # in WHITESPACE_ONLY mode, it is not possible to define IS_COMPILED_CODE
-      # so the value for IS_COMPILED_CODE is set by find and replace in the code
-      COMMAND ${CMAKE_COMMAND} -DFILENAME:STRING="${CMAKE_CURRENT_BINARY_DIR}/webodf-debug.js" -P ${CMAKE_CURRENT_SOURCE_DIR}/tools/set_IS_COMPILED_CODE.cmake
-      DEPENDS ClosureCompiler ${LIBJSFILES} tools/externs.js
-          webodf.css.js-target ${HEADERCOMPILED_FILE}
-  )
-  add_custom_target(webodf-debug.js-target DEPENDS webodf-debug.js)
+add_custom_command(
+    OUTPUT webodf-debug.js
+    COMMAND ${Java_JAVA_EXECUTABLE}
+    ARGS ${SHARED_CLOSURE_ARGS} --flagfile ${CMAKE_CURRENT_BINARY_DIR}/cc-noTestFiles.txt
+        --jscomp_error reportUnknownTypes
+        --define IS_COMPILED_CODE=true
+        --compilation_level WHITESPACE_ONLY
+        --formatting PRETTY_PRINT
+        --externs ${CMAKE_CURRENT_SOURCE_DIR}/tools/externs.js
+        --js_output_file webodf-debug.js-
+    # in WHITESPACE_ONLY mode, it is not possible to define IS_COMPILED_CODE
+    # so the value for IS_COMPILED_CODE is set by find and replace in the code
+    COMMAND ${CMAKE_COMMAND} -DFILENAME:STRING="${CMAKE_CURRENT_BINARY_DIR}/webodf-debug.js" -P ${CMAKE_CURRENT_SOURCE_DIR}/tools/set_IS_COMPILED_CODE.cmake
+    DEPENDS ClosureCompiler ${LIBJSFILES} tools/externs.js
+        webodf.css.js-target ${HEADERCOMPILED_FILE}
+)
+add_custom_target(webodf-debug.js-target DEPENDS webodf-debug.js)
 
-  add_custom_target(syntaxcheck ALL
-      DEPENDS simplecompiled.js-target webodf.js-target
-          compiled.js-target
-  )
+add_custom_target(syntaxcheck ALL
+    DEPENDS simplecompiled.js-target webodf.js-target
+        compiled.js-target
+)
 
 # rhino tests are disabled for now: rhino runtime lacks (wrappers for)
 # essential necessities such as Uint8Array, Node and NodeFilter
 # RHINOTEST is only defined here and hence undefined to disable rhinotest
 if (RHINOTEST)
-  add_custom_target(rhinotest
-      COMMAND ${Java_JAVA_EXECUTABLE} -jar ${RHINO}
-          -debug lib/runtime.js tests/tests.js
-      DEPENDS Rhino
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      SOURCES ${LIBJSFILES}
-  )
-  add_custom_target(simplerhinotest
-      COMMAND ${Java_JAVA_EXECUTABLE} -jar ${RHINO}
-          ${CMAKE_CURRENT_BINARY_DIR}/simplecompiled.js
-      DEPENDS Rhino simplecompiled.js-target
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
-  )
+add_custom_target(rhinotest
+    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${RHINO}
+        -debug lib/runtime.js tests/tests.js
+    DEPENDS Rhino
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    SOURCES ${LIBJSFILES}
+)
+add_custom_target(simplerhinotest
+    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${RHINO}
+        ${CMAKE_CURRENT_BINARY_DIR}/simplecompiled.js
+    DEPENDS Rhino simplecompiled.js-target
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+)
 endif (RHINOTEST)
 
-  add_custom_command(
-      OUTPUT docs/index.html
-       COMMAND ${Java_JAVA_EXECUTABLE}
-        ARGS -jar ${JSDOCDIR}/jsrun.jar
-            ${JSDOCDIR}/app/run.js -d=${CMAKE_CURRENT_BINARY_DIR}/docs
-                -t=${JSDOCDIR}/templates/jsdoc ${LIBJSFILES}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS ${LIBJSFILES} JsDoc
-  )
-  add_custom_target(doc DEPENDS docs/index.html)
-  add_custom_target(simplenodetest ALL
-      COMMAND ${NODE} ${CMAKE_CURRENT_BINARY_DIR}/simplecompiled.js
-      DEPENDS ${NODE} simplecompiled.js-target
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
-  )
-
-endif (Java_JAVA_EXECUTABLE)
+add_custom_command(
+    OUTPUT docs/index.html
+    COMMAND ${Java_JAVA_EXECUTABLE}
+    ARGS -jar ${JSDOCDIR}/jsrun.jar
+        ${JSDOCDIR}/app/run.js -d=${CMAKE_CURRENT_BINARY_DIR}/docs
+            -t=${JSDOCDIR}/templates/jsdoc ${LIBJSFILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${LIBJSFILES} JsDoc
+)
+add_custom_target(doc DEPENDS docs/index.html)
+add_custom_target(simplenodetest ALL
+    COMMAND ${NODE} ${CMAKE_CURRENT_BINARY_DIR}/simplecompiled.js
+    DEPENDS ${NODE} simplecompiled.js-target
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+)
 
 if (NOT APPLE)
     add_custom_command(


### PR DESCRIPTION
webodf.js needs it for closure compiler, and there is not much in the repo
which really makes sense to build without also building webodf.js

Played also with `project (WebODF C CXX Java)`, but that gave me

```
CMake Error: your Java compiler: "CMAKE_Java_COMPILER-NOTFOUND" was not found.   Please set CMAKE_Java_COMPILER to a valid compiler path or name.
```

which seemed strange and I could not find a quick solution to that, so left for future investigations.
