### PR TITLE
Add clearCache() to Runtime.

### DIFF
--- a/webodf/lib/runtime.js
+++ b/webodf/lib/runtime.js
@@ -127,6 +127,10 @@ Runtime.prototype.getFileSize = function (path, callback) {"use strict"; };
  */
 Runtime.prototype.deleteFile = function (path, callback) {"use strict"; };
 /**
+ * @return {undefined}
+ */
+Runtime.prototype.clearCache = function () {"use strict"; };
+/**
  * @param {!string} msgOrCategory
  * @param {!string=} msg
  * @return {undefined}
@@ -777,6 +781,12 @@ function BrowserRuntime(logoutput) {
         xhr.send(null);
     }
     /**
+     * @return {undefined}
+     */
+    this.clearCache = function () {
+        cache = {};
+    };
+    /**
      * @param {!string} path
      * @param {!function(?string,?Document):undefined} callback
      * @return {undefined}
@@ -1114,6 +1124,10 @@ function NodeJSRuntime() {
         path = pathmod.resolve(currentDirectory, path);
         fs.unlink(path, callback);
     };
+    /**
+     * @return {undefined}
+     */
+    this.clearCache = function () {};
     /**
      * @param {!string} path
      * @param {!number} offset
@@ -1470,6 +1484,10 @@ function RhinoRuntime() {
             callback("Could not delete " + path);
         }
     };
+    /**
+     * @return {undefined}
+     */
+    this.clearCache = function () {};
     /**
      * @param {!string} path
      * @param {!number} offset


### PR DESCRIPTION
This change was necessary to allow loading new documents dynamically (without refreshing the page).
