### PR TITLE
Add ChangeLog.md

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,25 @@
+# Changes between 0.5.0 and 0.5.1
+
+## WebODF
+
+### Improvements
+
+* numbering of multi-level lists is now well supported in rendering, including display of only a subset of the list numbers and continued numbering from previous lists (both `text:continue-numbering` and `text:continue-list`)
+([#565](https://github.com/kogmbh/WebODF/pull/565))
+
+### Fixes
+
+* Loading of documents without optional `<style:list-level-properties>` or `<style:list-level-label-alignment>` no longer fails and stalls
+* Loading of ODT files with annotations in Internet Explorer 10 (and possibly other versions) no longer fails and stalls
+
+
+## Wodo.TextEditor
+See also section about WebODF
+
+### Fixes
+
+* Start-up of editor no longer hangs in some browsers
+Two different bugs were fixed which so far broke the start-up with Safari and other browsers using older WebKit versions as well as the default browser on Android 4.0.3
+([#693](https://github.com/kogmbh/WebODF/issues/693))
+* All toolbar elements are now disabled when no document is loaded.
+([#709](https://github.com/kogmbh/WebODF/issues/709))


### PR DESCRIPTION
Thinking about the release of WebODF 0.5.1 ' one finds that a changelog would be useful, as possible users might want to know if upgrading their copy of WebODF/Wodo.TextEditor is worth the effort.
To compile the changelog, the release manager has to go through all the commits since the last release and see what was done. Which is not a joyful thing, as commit messages are not often perfectly written and especially with older commits or one where the person was not involved it is unclear what actually changed. Also are commit messages usually done with other project developers in mind. Where a changelog is instead interesting to the users of the products. They are interested if there are e.g. risks, new/lost features, fixes and breaking changes.

So I propose to maintain a file next to the commit messages, where we add all changes phrased in a way that product users get an idea about the change (perhaps even with hints how to use new features or adapt their code to API breakages). So in the future each PR would usually also have a commit/changes to this file.

Agreed to have that?

Please also check the actual content, as I would like to use exactly this text for the 0.5.1 release announcement ;)

' As wanted/needed to release ViewerJS, because that one is created mainly from code in the WebODF repo still and a clear version number for its WebODF plugin would be nice, which is taken from the WebODF version. But also exercising frequent releasing does not hurt :)
