### PR TITLE
Fix outline elements sneak from master pages into the shadow copies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,12 @@
+# Changes between 0.5.1 and 0.5.2
+
+## WebODF
+
+### Fixes
+
+* For ODP files sometimes template elements from the master pages were rendered inside the actual slides.
+
+
 # Changes between 0.5.0 and 0.5.1
 
 ## WebODF

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -248,7 +248,7 @@
     function dropTemplateDrawFrames(clonedNode) {
         // drop all frames which are just template frames
         var i, element, presentationClass,
-            clonedDrawFrameElements = clonedNode.getElementsByTagNameNS(drawns, 'frame');
+            clonedDrawFrameElements = domUtils.getElementsByTagNameNS(clonedNode, drawns, 'frame');
         for (i = 0; i < clonedDrawFrameElements.length; i += 1) {
             element = /**@type{!Element}*/(clonedDrawFrameElements[i]);
             presentationClass = element.getAttributeNS(presentationns, 'class');


### PR DESCRIPTION
Evil `getElementsByTagNameNS` returns a live node list, which of course adapts on the `element.parentNode.removeChild(element);`, so i++ skips the element after that...
