### PR TITLE
Provide hook to prevent browser alerts from being shown when logging

### DIFF
--- a/webodf/lib/runtime.js
+++ b/webodf/lib/runtime.js
@@ -325,6 +325,21 @@ Runtime.getFunctionName = function getFunctionName(f) {
     }
     return f.name;
 };
+
+/**
+ * @this {Runtime}
+ * @param {!boolean} condition
+ * @param {!string} message
+ * @return {undefined}
+ */
+Runtime.assert = function (condition, message) {
+    "use strict";
+    if (!condition) {
+        this.log("alert", "ASSERTION FAILED:\n" + message);
+        throw new Error(message); // interrupt execution and provide a backtrace
+    }
+};
+
 /**
  * @class
  * @constructor
@@ -513,17 +528,6 @@ function BrowserRuntime(logoutput) {
         }
     }
 
-    /**
-    * @param {!boolean} condition
-    * @param {!string} message
-    * @return {undefined}
-    */
-    function assert(condition, message) {
-        if (!condition) {
-            log("alert", "ASSERTION FAILED:\n" + message);
-            throw new Error(message); // interrupt execution and provide a backtrace
-        }
-    }
     /**
      * @param {!Array.<!number>} buffer
      * @return {!Uint8Array}
@@ -858,7 +862,7 @@ function BrowserRuntime(logoutput) {
     this.getFileSize = getFileSize;
     this.log = log;
     this.enableAlerts = true;
-    this.assert = assert;
+    this.assert = Runtime.assert;
     /**
      * @param {!function():undefined} f
      * @param {!number} msec
@@ -1188,17 +1192,9 @@ function NodeJSRuntime() {
         }
     }
     this.log = log;
-    /**
-    * @param {!boolean} condition
-    * @param {!string} message
-    * @return {undefined}
-    */
-    function assert(condition, message) {
-        if (!condition) {
-            process.stderr.write("ASSERTION FAILED: " + message);
-        }
-    }
-    this.assert = assert;
+
+    this.assert = Runtime.assert;
+
     /**
      * @param {!function():undefined} f
      * @param {!number} msec
@@ -1534,17 +1530,8 @@ function RhinoRuntime() {
     }
     this.log = log;
 
-    /**
-    * @param {!boolean} condition
-    * @param {!string} message
-    * @return {undefined}
-    */
-    function assert(condition, message) {
-        if (!condition) {
-            log("alert", "ASSERTION FAILED: " + message);
-        }
-    }
-    this.assert = assert;
+    this.assert = Runtime.assert;
+
     /**
      * @param {!function():undefined} f
      * @return {!number}


### PR DESCRIPTION
For automation and some uses of WebODF, a browser alert window is not a suitable way of communicating errors as they usually require user interaction. Though longer term WebODF should grow (or use) a more mature logging framework, for the immediate requirements for Bella I simply need a way of eliminating calls to alert.

This patch improves information provided when an assertion occurs, and cleans up the assert function parameters to remove the non-standard callback param.
