### PR TITLE
Create CSS rules for the attributes presentation:display-*

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 * For ODP files sometimes template elements from the master pages were rendered inside the actual slides.
 * Navigation via home/end keys, or up/down cursor keys is more reliable on all browsers. ([#555](https://github.com/kogmbh/WebODF/issues/555), [#405](https://github.com/kogmbh/WebODF/issues/405), [#224](https://github.com/kogmbh/WebODF/issues/224), [#185](https://github.com/kogmbh/WebODF/issues/185), [#124](https://github.com/kogmbh/WebODF/issues/124), [#98](https://github.com/kogmbh/WebODF/issues/98))
 * More elements from master pages are now correctly positioned when displayed inside slides.
+* In slides hide elements of class "header", "footer", "page-number" and "date-time" from master pages when configured so.
 
 
 # Changes between 0.5.0 and 0.5.1

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -642,6 +642,12 @@
 
                 // Now call setDrawElementPosition on this new page to set the proper dimensions
                 setDrawElementPosition(styleId, clonedPageElement, stylesheet);
+                // Add a custom attribute with the style name of the normal page, so the CSS rules created for the styles of the normal page
+                // to display/hide frames of certain classes from the master page can address the cloned master page belonging to that normal page
+                // Cmp. addDrawPageFrameDisplayRules in Style2CSS
+                clonedPageElement.setAttributeNS(webodfhelperns, 'page-style-name', element.getAttributeNS(drawns, 'style-name'));
+                // TODO: investigate if the attributes draw:style-name and style:page-layoutname should be copied over
+                // to the cloned page from the master page as well, or if this one below is enough already
                 // And finally, add an attribute referring to the master page, so the CSS targeted for that master page will style this
                 clonedPageElement.setAttributeNS(drawns, 'draw:master-page-name', masterPageElement.getAttributeNS(stylens, 'name'));
             }


### PR DESCRIPTION
Improves the display of many of my test ODP slides :)

Also achieves pretty similar results in LO and the viewer for
https://wiki.gnome.org/GUADEC/2014/LightningTalks/SlideDesign?action=AttachFile&do=view&target=lightning_talks.odp

Once this is in and 0.5.2 out, they will have no excuse not to use ViewerJS for their webpages and even presentations :)
