### PR TITLE
Add support in FF for double line-through

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## WebODF
 
+### Improvements
+
+* Add support for double line-through in Firefox (Chrome/Safari + IE don't support this feature) ([#755](https://github.com/kogmbh/WebODF/pull/755))
+
 ### Fixes
 
 * Fixed occasional crash when splitting a paragraph ([#723](https://github.com/kogmbh/WebODF/issues/723))

--- a/webodf/lib/odf/Style2CSS.js
+++ b/webodf/lib/odf/Style2CSS.js
@@ -402,7 +402,9 @@ odf.Style2CSS = function Style2CSS() {
      * @return {!string}
      */
     function getTextProperties(props) {
-        var rule = '', fontName, fontSize, value, textDecoration = '',
+        var rule = '', fontName, fontSize, value,
+            textDecorationLine = '',
+            textDecorationStyle = '',
             fontSizeRule = '',
             sizeMultiplier = 1,
             parentStyle;
@@ -411,16 +413,36 @@ odf.Style2CSS = function Style2CSS() {
 
         value = props.getAttributeNS(stylens, 'text-underline-style');
         if (value === 'solid') {
-            textDecoration += ' underline';
+            textDecorationLine += ' underline';
         }
         value = props.getAttributeNS(stylens, 'text-line-through-style');
         if (value === 'solid') {
-            textDecoration += ' line-through';
+            textDecorationLine += ' line-through';
         }
 
-        if (textDecoration.length) {
-            textDecoration = 'text-decoration:' + textDecoration + ';';
-            rule += textDecoration;
+        if (textDecorationLine.length) {
+            // CSS2
+            rule += 'text-decoration:' + textDecorationLine + ';\n';
+            // CSS3 text-decoration shorthand
+            rule += 'text-decoration-line:' + textDecorationLine + ';\n';
+            // CSS3 text-decoration shorthand - FF
+            rule += '-moz-text-decoration-line:' + textDecorationLine + ';\n';
+        }
+
+        value = props.getAttributeNS(stylens, 'text-line-through-type');
+        switch (value) {
+            case 'double':
+                textDecorationStyle += ' double';
+                break;
+            case 'single':
+                textDecorationStyle += ' single';
+                break;
+        }
+        if (textDecorationStyle) {
+            // CSS3
+            rule += 'text-decoration-style:' + textDecorationStyle + ';\n';
+            // CSS3 text-decoration shorthand - FF
+            rule += '-moz-text-decoration-style:' + textDecorationStyle + ';\n';
         }
 
         fontName = props.getAttributeNS(stylens, 'font-name')


### PR DESCRIPTION
Follows CSS3 standards. Unfortunately, only FF implements this so far.

Unfortunately, no layout tests are possible as getComputedStyle only returns style information it understands, which differs from browser to browser. It is possible to write a layouttest that passes in FF, or one that passes in Chrome (not that I can check anything in Chrome), but not one that passes in both.
