### PR TITLE
Simplify convertDomPointToCursorStep method

### DIFF
--- a/programs/editor/EditorSession.js
+++ b/programs/editor/EditorSession.js
@@ -86,7 +86,7 @@ define("webodf/editor/EditorSession", [
             shadowCursor = new gui.ShadowCursor(odtDocument),
             sessionConstraints,
             /**@const*/
-            NEXT = ops.OdtStepsTranslator.NEXT_STEP;
+            NEXT = core.StepDirection.NEXT;
 
         /**
          * @return {Array.<!string>}

--- a/webodf/lib/core/StepIterator.js
+++ b/webodf/lib/core/StepIterator.js
@@ -39,6 +39,8 @@ core.StepIterator = function StepIterator(filter, iterator) {
 
     var /**@const*/
         FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT,
+        /**@const*/
+        NEXT = core.StepDirection.NEXT,
         cachedContainer,
         cachedOffset,
         cachedFilterResult;
@@ -139,7 +141,7 @@ core.StepIterator = function StepIterator(filter, iterator) {
      * @return {!boolean}
      */
     this.advanceStep = function(direction) {
-        return direction === core.StepDirection.NEXT ? nextStep() : previousStep();
+        return direction === NEXT ? nextStep() : previousStep();
     };
 
     /**

--- a/webodf/lib/gui/AnnotationController.js
+++ b/webodf/lib/gui/AnnotationController.js
@@ -39,7 +39,7 @@ gui.AnnotationController = function AnnotationController(session, sessionConstra
         eventNotifier = new core.EventNotifier([gui.AnnotationController.annotatableChanged]),
         odfUtils = new odf.OdfUtils(),
         /**@const*/
-        NEXT = ops.OdtStepsTranslator.NEXT_STEP;
+        NEXT = core.StepDirection.NEXT;
 
     /**
      * @return {undefined}

--- a/webodf/lib/gui/DirectFormattingController.js
+++ b/webodf/lib/gui/DirectFormattingController.js
@@ -58,7 +58,7 @@ gui.DirectFormattingController = function DirectFormattingController(
         /**@const*/
         textns = odf.Namespaces.textns,
         /**@const*/
-        NEXT = ops.OdtStepsTranslator.NEXT_STEP,
+        NEXT = core.StepDirection.NEXT,
         /**@type{?odf.Formatting.StyleData}*/
         directCursorStyleProperties = null,
         // cached text settings

--- a/webodf/lib/gui/PasteController.js
+++ b/webodf/lib/gui/PasteController.js
@@ -22,7 +22,7 @@
  * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global runtime, gui, ops, odf*/
+/*global runtime, gui, ops, odf, core*/
 
 /**
  * Provides a method to paste text at the current cursor
@@ -43,7 +43,7 @@ gui.PasteController = function PasteController(session, sessionConstraints, sess
         /**@const*/
         textns = odf.Namespaces.textns,
         /**@const*/
-        NEXT = ops.OdtStepsTranslator.NEXT_STEP;
+        NEXT = core.StepDirection.NEXT;
 
     /**
      * @return {undefined}

--- a/webodf/lib/gui/TextController.js
+++ b/webodf/lib/gui/TextController.js
@@ -61,7 +61,7 @@ gui.TextController = function TextController(
         /** @const */
         textns = odf.Namespaces.textns,
         /**@const*/
-        NEXT = ops.OdtStepsTranslator.NEXT_STEP;
+        NEXT = core.StepDirection.NEXT;
 
     /**
      * @return {undefined}

--- a/webodf/lib/manifest.json
+++ b/webodf/lib/manifest.json
@@ -372,6 +372,7 @@
     ],
     "ops.OdtStepsTranslator": [
         "core.PositionFilter",
+        "core.enums",
         "odf.OdfUtils",
         "ops.StepsCache"
     ],

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -72,7 +72,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         /**@const*/
         FILTER_REJECT = core.PositionFilter.FilterResult.FILTER_REJECT,
         /**@const*/
-        NEXT = ops.OdtStepsTranslator.NEXT_STEP,
+        NEXT = core.StepDirection.NEXT,
         filter,
         /**@type{!ops.OdtStepsTranslator}*/
         stepsTranslator,
@@ -263,7 +263,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
 
     /**
      * Rounds to the first step within the paragraph
-     * @param {!number} step
+     * @param {!core.StepDirection} step
      * @return {!boolean}
      */
     function roundUp(step) {
@@ -275,7 +275,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
      * the default is to round down to the previous step.
      * @param {!Node} node
      * @param {!number} offset
-     * @param {!number=} roundDirection Whether to round down to the previous step or round up to the next step
+     * @param {core.StepDirection=} roundDirection Whether to round down to the previous step or round up
+     * to the next step. The default value if unspecified is core.StepDirection.PREVIOUS
      * @return {!number}
      */
     this.convertDomPointToCursorStep = function (node, offset, roundDirection) {

--- a/webodf/lib/ops/OdtStepsTranslator.js
+++ b/webodf/lib/ops/OdtStepsTranslator.js
@@ -26,17 +26,6 @@
 
 (function () {
     "use strict";
-    var
-        /**
-         * @const
-         * @type {!number}
-         */
-        PREVIOUS_STEP = 0,
-        /**
-         * @const
-         * @type {!number}
-         */
-        NEXT_STEP = 1;
 
     /**
      *
@@ -55,7 +44,11 @@
             /**@type{!core.PositionIterator}*/
             iterator,
             /**@const*/
-            FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT;
+            FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT,
+            /**@const*/
+            PREVIOUS = core.StepDirection.PREVIOUS,
+            /**@const*/
+            NEXT = core.StepDirection.NEXT;
 
         /**
          * Update the steps cache based on the current iterator position. This can either add new
@@ -163,7 +156,7 @@
         /**
          * Uses the provided delegate to choose between rounding up or rounding down to the nearest step.
          * @param {!core.PositionIterator} iterator
-         * @param {function(!number, !Node, !number):boolean=} roundDirection
+         * @param {function(!core.StepDirection, !Node, !number):boolean=} roundDirection
          * @return {!boolean} Returns true if an accepted position is found, otherwise returns false.
          */
         function roundToPreferredStep(iterator, roundDirection) {
@@ -173,7 +166,7 @@
 
             while (iterator.previousPosition()) {
                 if (filter.acceptPosition(iterator) === FILTER_ACCEPT) {
-                    if (roundDirection(PREVIOUS_STEP, iterator.container(), iterator.unfilteredDomOffset())) {
+                    if (roundDirection(PREVIOUS, iterator.container(), iterator.unfilteredDomOffset())) {
                         return true;
                     }
                     break;
@@ -182,7 +175,7 @@
 
             while (iterator.nextPosition()) {
                 if (filter.acceptPosition(iterator) === FILTER_ACCEPT) {
-                    if (roundDirection(NEXT_STEP, iterator.container(), iterator.unfilteredDomOffset())) {
+                    if (roundDirection(NEXT, iterator.container(), iterator.unfilteredDomOffset())) {
                         return true;
                     }
                     break;
@@ -200,7 +193,7 @@
          * behaviour is to round down.
          * @param {!Node} node
          * @param {!number} offset
-         * @param {function(!number, !Node, !number):!boolean=} roundDirection
+         * @param {function(!core.StepDirection, !Node, !number):!boolean=} roundDirection
          * @return {!number}
          */
         this.convertDomPointToSteps = function (node, offset, roundDirection) {
@@ -301,16 +294,4 @@
         }
         init();
     };
-
-    /**
-     * @const
-     * @type {!number}
-     */
-    ops.OdtStepsTranslator.PREVIOUS_STEP = PREVIOUS_STEP;
-
-    /**
-     * @const
-     * @type {!number}
-     */
-    ops.OdtStepsTranslator.NEXT_STEP = NEXT_STEP;
 }());

--- a/webodf/tests/manifest.json
+++ b/webodf/tests/manifest.json
@@ -189,12 +189,12 @@
     ],
     "ops.OdtDocumentTests": [
         "core.UnitTester",
+        "core.enums",
         "odf.Namespaces",
         "odf.OdfCanvas",
         "odf.OdfNodeFilter",
         "ops.OdtCursor",
         "ops.OdtDocument",
-        "ops.OdtStepsTranslator",
         "xmldom.LSSerializer",
         "xmldom.LSSerializerFilter"
     ],
@@ -203,19 +203,20 @@
         "core.PositionFilter",
         "core.PositionIterator",
         "core.UnitTester",
+        "core.enums",
         "odf.Namespaces",
         "ops.OdtStepsTranslator",
         "ops.TextPositionFilter"
     ],
     "ops.OperationTests": [
         "core.UnitTester",
+        "core.enums",
         "odf.Namespaces",
         "odf.OdfCanvas",
         "odf.OdfContainer",
         "ops.Document",
         "ops.Member",
         "ops.OdtDocument",
-        "ops.OdtStepsTranslator",
         "ops.OperationFactory",
         "xmldom.LSSerializer"
     ],

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -36,7 +36,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
         testarea,
         inputMemberId = "Joe",
         /**@const*/
-        PREVIOUS = ops.OdtStepsTranslator.PREVIOUS_STEP,
+        PREVIOUS = core.StepDirection.PREVIOUS,
         prefixToNamespace = {
             fo: odf.Namespaces.namespaceMap.fo,
             text: odf.Namespaces.namespaceMap.text,

--- a/webodf/tests/ops/OdtStepsTranslatorTests.js
+++ b/webodf/tests/ops/OdtStepsTranslatorTests.js
@@ -39,11 +39,11 @@ ops.OdtStepsTranslatorTests = function OdtStepsTranslatorTests(runner) {
         CACHE_STEP_SIZE = 5;
 
     function roundDown(step) {
-        return step === ops.OdtStepsTranslator.PREVIOUS_STEP;
+        return step === core.StepDirection.PREVIOUS;
     }
 
     function roundUp(step) {
-        return step === ops.OdtStepsTranslator.NEXT_STEP;
+        return step === core.StepDirection.NEXT;
     }
 
     /**

--- a/webodf/tests/ops/OperationTests.js
+++ b/webodf/tests/ops/OperationTests.js
@@ -166,7 +166,7 @@ ops.OperationTests = function OperationTests(runner) {
     function verifyStepsCache() {
         var rootNode = t.odtDocument.getRootNode();
         // Asking for the maximum available step will cause the cache to reverify itself completely
-        t.odtDocument.convertDomPointToCursorStep(rootNode, rootNode.childNodes.length, ops.OdtStepsTranslator.PREVIOUS_STEP);
+        t.odtDocument.convertDomPointToCursorStep(rootNode, rootNode.childNodes.length, core.StepDirection.PREVIOUS);
     }
 
     function parseTest(name, node) {


### PR DESCRIPTION
This `convertDomPointToCursorStep` method on `OdtDocument` has a parameter that lets the caller provide a function to customise the rounding behaviour. In practice the callers of this method simply use the default fallback of rounding down or provide the same duplicate function to get round up behaviour.

This PR simplifies the interface by only providing an option to either round down or round up when converting to steps. This does not touch the `OdtStepsTranslator` interface so any class that might need custom rounding behaviour in the future can still access it directly from the steps translator.
