### PR TITLE
Fix preservation of foreign elements on paragraph merge

### DIFF
--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -682,7 +682,7 @@
   </ops>
   <after><office:text><text:p text:style-name="B"><foreign:test foreign:id="1"/><foreign:test foreign:id="2"/><foreign:test foreign:id="3"/>efgh<foreign:test foreign:id="4"/></text:p></office:text></after>
  </test>
- <test name="Merge_Empty_WithNonOdfChildren_PreservesForeignElements" isFailing="true">
+ <test name="Merge_Empty_WithNonOdfChildren_PreservesForeignElements">
   <before><office:text><text:p><foreign:test foreign:id="1"/></text:p><text:p><text:span><foreign:test foreign:id="2"/></text:span></text:p></office:text></before>
   <ops>
    <op optype="MergeParagraph" destinationStartPosition="0" sourceStartPosition="1"/>


### PR DESCRIPTION
This behaviour was working prior to the merge paragraph operation being introduced. A new edge case was introduced related to cleaning up empty spans that caused this to regress.
