### PR TITLE
Allow merge paragraph to handle unexpected nodes near paragraph boundaries

### DIFF
--- a/webodf/tests/ops/operationtests.xml
+++ b/webodf/tests/ops/operationtests.xml
@@ -697,7 +697,7 @@
   </ops>
   <after><office:text><text:p/><text:p><c:cursor c:memberId="Alice"/>B</text:p></office:text></after>
  </test>
- <test name="Merge_CopesWithOddElements_AtParagraphBounds" isFailing="true">
+ <test name="Merge_CopesWithOddElements_AtParagraphBounds">
   <before><office:text><text:p/><text:p><text:hidden-text>hidden</text:hidden-text>B</text:p></office:text></before>
   <ops>
    <op optype="MergeParagraph" memberid="Alice" destinationStartPosition="0" sourceStartPosition="1"/>


### PR DESCRIPTION
getTextElements may return some unexpected text nodes if the step filters haven't correctly identified the first/last step in the paragraph. Rather than failing completely in this case as the assert causes, simply log the unexpected items and skip them.

getTextElements itself still needs to be fixed, but the harm caused by such mistakes is slightly reduced in this instance.
