### PR TITLE
Add alignWithTop flag to indicate rect should be scrolled to top of view

### DIFF
--- a/webodf/lib/gui/SingleScrollViewport.js
+++ b/webodf/lib/gui/SingleScrollViewport.js
@@ -69,9 +69,10 @@ gui.SingleScrollViewport = function(scrollPane) {
 
     /**
      * @param {?core.SimpleClientRect} clientRect
+     * @param {!boolean=} alignWithTop
      * @return {undefined}
      */
-    this.scrollIntoView = function(clientRect) {
+    this.scrollIntoView = function(clientRect, alignWithTop) {
         var verticalScrollbarHeight = scrollPane.offsetHeight - scrollPane.clientHeight,
             horizontalScrollbarWidth = scrollPane.offsetWidth - scrollPane.clientWidth,
             nonNullClientRect,
@@ -95,7 +96,7 @@ gui.SingleScrollViewport = function(scrollPane) {
         });
 
         // Vertical adjustment
-        if (nonNullClientRect.top < paneRect.top) {
+        if (alignWithTop || nonNullClientRect.top < paneRect.top) {
             // Scroll top down into view
             scrollPane.scrollTop -= paneRect.top - nonNullClientRect.top;
         } else if (nonNullClientRect.top > paneRect.bottom || nonNullClientRect.bottom > paneRect.bottom) {

--- a/webodf/lib/gui/Viewport.js
+++ b/webodf/lib/gui/Viewport.js
@@ -40,6 +40,8 @@ gui.Viewport = function Viewport() { "use strict"; };
  * on screen. Similar logic applies if the clientRect width is too large.
  *
  * @param {?core.SimpleClientRect} clientRect
+ * @param {!boolean=} alignWithTop Align the clientRect to the top of the viewport. If unspecified or false, the
+ *  view will scroll only as much as required to bring the clientRect into view.
  * @return {undefined}
  */
-gui.Viewport.prototype.scrollIntoView = function(clientRect) { "use strict"; };
+gui.Viewport.prototype.scrollIntoView = function(clientRect, alignWithTop) { "use strict"; };


### PR DESCRIPTION
This mirrors the HTML flag of the same name:
https://developer.mozilla.org/en-US/docs/Web/API/element.scrollIntoView

This feature is unused within WebODF, but I have need for it externally for a custom find panel. The code change seemed simple enough so I have raised a PR here, feel free to close however if this is undesirable.

For reviewing and testing purposes, I manually modified the `gui.Caret` scrollIntoView call to specify the new flag as true, and then ensured the caret was always scrolled to the top (it makes for a very jarring editing experience by the way!).
