### PR TITLE
CSS tweaks to improve display of empty paragraphs & tables

### DIFF
--- a/webodf/webodf.css
+++ b/webodf/webodf.css
@@ -270,6 +270,7 @@ cursor|cursor {
     top: 5%; /* push down the caret; 0px can do the job, 5% looks better, 10% is a bit over */
     height: 1em;
     z-index: 10;
+    padding-left: 1px; /* centre 2px caret into middle of overlay */
     pointer-events: none;
 }
 


### PR DESCRIPTION
Two minor tweaks to make the display of the caret within a table more professional looking:
1. Use `::after` pseudo-element to prevent empty paragraphs from collapsing rather than min-height
2. Horizontally centre caret slightly better between characters

![adjusted-layouts](https://cloud.githubusercontent.com/assets/1052079/3951536/200b6eea-26d8-11e4-90f1-2f7424eb4ec9.png)
