### PR TITLE
Fix setUnfilteredPosition to escape child text nodes of rejected parents

### DIFF
--- a/webodf/lib/core/PositionIterator.js
+++ b/webodf/lib/core/PositionIterator.js
@@ -425,10 +425,7 @@ core.PositionIterator = function PositionIterator(root, whatToShow, filter,
                     runtime.assert(false, "Error in setUnfilteredPosition: position not valid.");
                 }
             }
-            return true;
-        }
-
-        if (offset < container.childNodes.length) {
+        } else if (offset < container.childNodes.length) {
             // Immediately advance to the child node at that offset to begin iteration.
             // This is necessary in order to satisfy the most frequent use case where developer will
             // store the (container, unfilteredDomOffset) from a previous position iterator, and use

--- a/webodf/tests/core/PositionIteratorTests.js
+++ b/webodf/tests/core/PositionIteratorTests.js
@@ -400,6 +400,16 @@ core.PositionIteratorTests = function PositionIteratorTests(runner) {
         r.shouldBe(t, "t.iterator.container().getAttribute('id')", "'a1'");
         r.shouldBe(t, "t.iterator.unfilteredDomOffset()", "0");
     }
+    function testSetUnfilteredPosition_TextChildOfInvalidNode_ImmediatelyMovesToNextValidPosition() {
+        createWalker('<p><b id="b1">TEXT</b><a id="a1"/></p>');
+        t.iterator.setUnfilteredPosition(t.doc.documentElement.childNodes[0].childNodes[0], 0); // #text "TEXT"
+        r.shouldBe(t, "t.iterator.container()", "t.doc.documentElement");
+        r.shouldBe(t, "t.iterator.unfilteredDomOffset()", "1");
+
+        t.iterator.nextPosition();
+        r.shouldBe(t, "t.iterator.container().getAttribute('id')", "'a1'");
+        r.shouldBe(t, "t.iterator.unfilteredDomOffset()", "0");
+    }
     function testSetUnfilteredPosition_GrandChildOfInvalidNode_ImmediatelyMovesToNextValidPosition() {
         createWalker('<p><b id="b1"><a id="a0"><a id="a0.0"/></a></b><a id="a1"/></p>');
         t.iterator.setUnfilteredPosition(t.doc.documentElement.childNodes[0].childNodes[0].childNodes[0], 0); // a0.0
@@ -583,6 +593,7 @@ core.PositionIteratorTests = function PositionIteratorTests(runner) {
             testSetUnfilteredPosition_UsesUnfilteredOffsets,
             testSetUnfilteredPosition_ImmediatelyMovesToNextValidPosition,
             testSetUnfilteredPosition_ChildOfInvalidNode_ImmediatelyMovesToNextValidPosition,
+            testSetUnfilteredPosition_TextChildOfInvalidNode_ImmediatelyMovesToNextValidPosition,
             testSetUnfilteredPosition_GrandChildOfInvalidNode_ImmediatelyMovesToNextValidPosition,
             testSetUnfilteredPosition_ChildOfNestedInvalidNodes_ImmediatelyMovesToNextValidPosition,
             testSetUnfilteredPosition_HandlesChildNodesCorrectly,


### PR DESCRIPTION
setUnfilteredPosition was incorrectly leaving the walker's currentNode
inside a rejected parent if the target node was a TEXT_NODE. Adjusted
branching logic to ensure the walker always moves to a valid position
if the specified position is not accepted by the current filters.

Fixes #797
