### PR TITLE
Change missed runtime.read hooks to override runtime.readFile instead

### DIFF
--- a/programs/docnosis/docnosis.js
+++ b/programs/docnosis/docnosis.js
@@ -694,17 +694,17 @@ function LoadingFile(file) {
         reader.readAsBinaryString(file);
     }
     this.file = file;
-    this.read = function (offset, length, callback) {
-        function read() {
+    this.readFile = function (callback) {
+        function readFile() {
             if (error) {
                 return callback(error);
             }
             if (data) {
-                return callback(error, data.subarray(offset, offset + length));
+                return callback(error, data);
             }
-            readRequests.push(read);
+            readRequests.push(readFile);
         }
-        read();
+        readFile();
     };
     this.load = load;
 }
@@ -783,12 +783,12 @@ function Docnosis(element) {
     }
 
     function enhanceRuntime() {
-        var read = runtime.read;
-        runtime.read = function (path, offset, length, callback) {
+        var readFile = runtime.readFile;
+        runtime.readFile = function (path, encoding, callback) {
             if (openedFiles.hasOwnProperty(path)) {
-                return openedFiles[path].read(offset, length, callback);
+                return openedFiles[path].readFile(callback);
             } else {
-                return read(path, offset, length, callback);
+                return readFile(path, encoding, callback);
             }
         };
     }

--- a/programs/editor/localfileeditor.js
+++ b/programs/editor/localfileeditor.js
@@ -77,14 +77,14 @@ function createEditor() {
 
     function enhanceRuntime() {
         var openedFiles = {},
-            read = runtime.read;
-        runtime.read = function (path, offset, length, callback) {
+            readFile = runtime.readFile;
+        runtime.readFile = function (path, encoding, callback) {
             var array;
             if (openedFiles.hasOwnProperty(path)) {
-                array = new Uint8Array(openedFiles[path], offset, length);
+                array = new Uint8Array(openedFiles[path]);
                 callback(undefined, array);
             } else {
-                return read(path, offset, length, callback);
+                return readFile(path, encoding, callback);
             }
         };
         runtime.registerFile = function (path, data) {

--- a/programs/editor/revieweditor.js
+++ b/programs/editor/revieweditor.js
@@ -77,14 +77,14 @@ function createReviewEditor() {
 
     function enhanceRuntime() {
         var openedFiles = {},
-            read = runtime.read;
-        runtime.read = function (path, offset, length, callback) {
+            readFile = runtime.readFile;
+        runtime.readFile = function (path, encoding, callback) {
             var array;
             if (openedFiles.hasOwnProperty(path)) {
-                array = new Uint8Array(openedFiles[path], offset, length);
+                array = new Uint8Array(openedFiles[path]);
                 callback(undefined, array);
             } else {
-                return read(path, offset, length, callback);
+                return readFile(path, encoding, callback);
             }
         };
         runtime.registerFile = function (path, data) {

--- a/programs/touchui/app/views/OdfView.js
+++ b/programs/touchui/app/views/OdfView.js
@@ -57,25 +57,16 @@ Ext.define('WebODFApp.view.OdfView', (function () {
         }
     }
     function initCanvas() {
-        var cmp;
         if (globalreadfunction === undefined) {
             // overload the global read function with one that only reads
             // the data from this canvas
-            globalreadfunction = runtime.read;
-            globalfilesizefunction = runtime.getFileSize;
-            runtime.read = function (path, offset, length, callback) {
+            globalreadfunction = runtime.readFile;
+            runtime.readFile = function (path, encoding, callback) {
                 if (path !== overridePath) {
                     globalreadfunction.apply(runtime,
-                        [path, offset, length, callback]);
+                        [path, encoding, callback]);
                 } else {
-                    callback(null, data.subarray(offset, offset + length));
-                }
-            };
-            runtime.getFileSize = function (path, callback) {
-                if (path !== overridePath) {
-                    globalfilesizefunction.apply(runtime, [path, callback]);
-                } else {
-                    callback(data.length);
+                    callback(null, data);
                 }
             };
             dom = Ext.getCmp('webodf').element.dom;


### PR DESCRIPTION
These hooks are all intended to override file loading within odf.Zip. As odf.Zip now uses runtime.readFile, these hooks all need to be updated as well.
