### PR TITLE
Stricter typing of the setProperties data

### DIFF
--- a/webodf/lib/ops/OpAddStyle.js
+++ b/webodf/lib/ops/OpAddStyle.js
@@ -33,7 +33,7 @@ ops.OpAddStyle = function OpAddStyle() {
 
     var memberid, timestamp,
         styleName, styleFamily, isAutomaticStyle,
-        /**@type{Object}*/setProperties,
+        /**@type{!odf.Formatting.StyleData}*/setProperties,
         /** @const */stylens = odf.Namespaces.stylens;
 
     /**
@@ -110,7 +110,7 @@ ops.OpAddStyle = function OpAddStyle() {
     styleName:string,
     styleFamily:string,
     isAutomaticStyle:boolean,
-    setProperties:Object
+    setProperties:odf.Formatting.StyleData
 }}*/
 ops.OpAddStyle.Spec;
 /**@typedef{{
@@ -119,6 +119,6 @@ ops.OpAddStyle.Spec;
     styleName:string,
     styleFamily:string,
     isAutomaticStyle:(boolean|string),
-    setProperties:Object
+    setProperties:odf.Formatting.StyleData
 }}*/
 ops.OpAddStyle.InitSpec;

--- a/webodf/lib/ops/OpApplyDirectStyling.js
+++ b/webodf/lib/ops/OpApplyDirectStyling.js
@@ -36,6 +36,7 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
         position,
         /**@type {number}*/
         length,
+        /**@type{!odf.Formatting.StyleData}*/
         setProperties,
         odfUtils = odf.OdfUtils,
         domUtils = core.DomUtils;
@@ -123,7 +124,7 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
     timestamp:number,
     position:number,
     length:number,
-    setProperties:!Object
+    setProperties:!odf.Formatting.StyleData
 }}*/
 ops.OpApplyDirectStyling.Spec;
 /**@typedef{{
@@ -131,6 +132,6 @@ ops.OpApplyDirectStyling.Spec;
     timestamp:(number|undefined),
     position:number,
     length:number,
-    setProperties:!Object
+    setProperties:!odf.Formatting.StyleData
 }}*/
 ops.OpApplyDirectStyling.InitSpec;

--- a/webodf/lib/ops/OpUpdateParagraphStyle.js
+++ b/webodf/lib/ops/OpUpdateParagraphStyle.js
@@ -32,6 +32,7 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
     "use strict";
 
     var memberid, timestamp, styleName,
+        /**@type{!odf.Formatting.StyleData}*/
         setProperties,
         /**@type{{attributes:string}}*/
         removedProperties,
@@ -147,7 +148,7 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
     memberid:string,
     timestamp:number,
     styleName:string,
-    setProperties:Object,
+    setProperties:!odf.Formatting.StyleData,
     removedProperties:{attributes:string}
 }}*/
 ops.OpUpdateParagraphStyle.Spec;
@@ -155,7 +156,7 @@ ops.OpUpdateParagraphStyle.Spec;
     memberid:string,
     timestamp:(number|undefined),
     styleName:string,
-    setProperties:Object,
+    setProperties:!odf.Formatting.StyleData,
     removedProperties:{attributes:string}
 }}*/
 ops.OpUpdateParagraphStyle.InitSpec;

--- a/webodf/lib/ops/OperationTransformMatrix.js
+++ b/webodf/lib/ops/OperationTransformMatrix.js
@@ -60,8 +60,8 @@ ops.OperationTransformMatrix = function OperationTransformMatrix() {
 
     /**
      * Returns a list with all attributes in setProperties that refer to styleName
-     * @param {Object} setProperties
-     * @param {string} styleName
+     * @param {?odf.Formatting.StyleData} setProperties
+     * @param {!string} styleName
      * @return {!Array.<!string>}
      */
     function getStyleReferencingAttributes(setProperties, styleName) {
@@ -80,8 +80,9 @@ ops.OperationTransformMatrix = function OperationTransformMatrix() {
         return attributes;
     }
     /**
-     * @param {Object} setProperties
-     * @param {string} deletedStyleName
+     * @param {?odf.Formatting.StyleData} setProperties
+     * @param {!string} deletedStyleName
+     * @return {undefined}
      */
     function dropStyleReferencingAttributes(setProperties, deletedStyleName) {
         /**
@@ -194,7 +195,7 @@ ops.OperationTransformMatrix = function OperationTransformMatrix() {
 
     /**
      * Estimates if there are any properties set in the given properties object.
-     * @param {!Object} properties
+     * @param {!odf.Formatting.StyleData} properties
      * @return {!boolean}
      */
     function hasProperties(properties) {
@@ -230,20 +231,21 @@ ops.OperationTransformMatrix = function OperationTransformMatrix() {
     }
 
     /**
-     * @param {Object.<string,Object.<string,*>>} minorSet
-     * @param {Object.<string,{attributes:string}>} minorRem
-     * @param {Object.<string,Object.<string,*>>} majorSet
-     * @param {Object.<string,{attributes:string}>} majorRem
-     * @param {string} propertiesName
+     * @param {?odf.Formatting.StyleData} minorSet
+     * @param {?Object.<string,{attributes:string}>} minorRem
+     * @param {?odf.Formatting.StyleData} majorSet
+     * @param {?Object.<string,{attributes:string}>} majorRem
+     * @param {!string} propertiesName
      * @return {?{majorChanged:boolean,minorChanged:boolean}}
      */
     function dropOverruledAndUnneededProperties(minorSet, minorRem, majorSet, majorRem, propertiesName) {
-        var minorSP = minorSet ? minorSet[propertiesName] : null,
+        var minorSP = /**@type{?odf.Formatting.StyleData}*/(minorSet ? minorSet[propertiesName] : null),
             minorRP = minorRem ? minorRem[propertiesName] : null,
-            majorSP = majorSet ? majorSet[propertiesName] : null,
+            majorSP = /**@type{?odf.Formatting.StyleData}*/(majorSet ? majorSet[propertiesName] : null),
             majorRP = majorRem ? majorRem[propertiesName] : null,
             result;
 
+        // TODO: also care for nested properties, like there can be e.g. with text:paragraph-properties
         result = dropOverruledAndUnneededAttributes(minorSP, minorRP, majorSP, majorRP);
 
         // remove empty setProperties


### PR DESCRIPTION
Caught my attention while comparing current ops with those new in 674

No errors seen or caught, but might prevent future ones.

Added a TODO explicitely which so far was only in my bad conscience... :innocent: 
