### PR TITLE
Ensure cursor is restored to step after refreshing annotations

### DIFF
--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -119,6 +119,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         }
         initialDoc = rootElement.cloneNode(true);
         odfCanvas.refreshAnnotations();
+        // Forgetting and then refreshing the annotations may cause the cursor to end up in a non-step position
+        self.fixCursorPositions();
         return initialDoc;
     };
 


### PR DESCRIPTION
Clearing and then drawing the annotations may cause the cursor to end up in a non-step position.

This bug is not currently reproducible in the demo editor, as it relies on the ``OdtDocument.cloneDocumentElement`` function being called, something which is currently only done by the TrivialUndoManager to save the initial document state. Bella does do this somewhat regularly during fuzzing however.