### PR TITLE
Remove duplicate function definition

### DIFF
--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -108,12 +108,6 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     this.getDocumentElement = function () {
         return odfCanvas.odfContainer().rootElement;
     };
-    /**
-     * @return {!Document}
-     */
-    this.getDOMDocument = function () {
-        return /**@type{!Document}*/(this.getDocumentElement().ownerDocument);
-    };
 
     this.cloneDocumentElement = function () {
         var rootElement = self.getDocumentElement(),


### PR DESCRIPTION
getDOMDocument is already defined a few lines below, using the more standard "self" reference rather than "this".

Noticed in passing...
