### PR TITLE
Reduce the number of places aware that the root element can be replaced

### DIFF
--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -126,12 +126,21 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
      * @param {!Element} documentElement
      */
     this.setDocumentElement = function (documentElement) {
-        var odfContainer = odfCanvas.odfContainer();
+        var odfContainer = odfCanvas.odfContainer(),
+            rootNode;
+
+        eventNotifier.unsubscribe(ops.OdtDocument.signalStepsInserted, stepsTranslator.handleStepsInserted);
+        eventNotifier.unsubscribe(ops.OdtDocument.signalStepsRemoved, stepsTranslator.handleStepsRemoved);
+
         // TODO Replace with a neater hack for reloading the Odt tree
-        // Once this is fixed, SelectionView.addOverlays & OdtStepsTranslator.verifyRootNode can be largely removed
+        // Once this is fixed, SelectionView.addOverlays can be removed
         odfContainer.setRootElement(documentElement);
         odfCanvas.setOdfContainer(odfContainer, true);
         odfCanvas.refreshCSS();
+        rootNode = getRootNode();
+        stepsTranslator = new ops.OdtStepsTranslator(rootNode, createPositionIterator(rootNode), filter, 500);
+        eventNotifier.subscribe(ops.OdtDocument.signalStepsInserted, stepsTranslator.handleStepsInserted);
+        eventNotifier.subscribe(ops.OdtDocument.signalStepsRemoved, stepsTranslator.handleStepsRemoved);
     };
 
     /**
@@ -932,9 +941,11 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
      * @return {undefined}
      */
     function init() {
+        var rootNode = getRootNode();
+
         filter = new ops.TextPositionFilter();
         stepUtils = new odf.StepUtils();
-        stepsTranslator = new ops.OdtStepsTranslator(getRootNode, createPositionIterator, filter, 500);
+        stepsTranslator = new ops.OdtStepsTranslator(rootNode, createPositionIterator(rootNode), filter, 500);
         eventNotifier.subscribe(ops.OdtDocument.signalStepsInserted, stepsTranslator.handleStepsInserted);
         eventNotifier.subscribe(ops.OdtDocument.signalStepsRemoved, stepsTranslator.handleStepsRemoved);
         eventNotifier.subscribe(ops.OdtDocument.signalOperationEnd, handleOperationExecuted);

--- a/webodf/tests/ops/OdtStepsTranslatorTests.js
+++ b/webodf/tests/ops/OdtStepsTranslatorTests.js
@@ -138,9 +138,7 @@ ops.OdtStepsTranslatorTests = function OdtStepsTranslatorTests(runner) {
         t = {
             filter: new CallCountedPositionFilter(new ops.TextPositionFilter())
         };
-        t.translator = new ops.OdtStepsTranslator(function() { return testarea; },
-            createPositionIterator,
-            t.filter, CACHE_STEP_SIZE);
+        t.translator = new ops.OdtStepsTranslator(testarea, createPositionIterator(testarea), t.filter, CACHE_STEP_SIZE);
     };
     this.tearDown = function () {
         t = {};


### PR DESCRIPTION
Replacing the root element is currently a by-product of the undo impl. Reducing the number of places aware of this impl detail helps ensure future undo managers have less clean-up work to do when this behaviour is finally removed.

# Local testing done
* Undo/redo, and ensured text input + mouse selection still works
* Ensure multiple steps can be undone & redone