### PR TITLE
Remove hardcoded dep of OdtDocument code on op UpdateMetadata

### DIFF
--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -442,32 +442,25 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
             date = new Date(opspec.timestamp).toISOString(),
             odfContainer = odfCanvas.odfContainer(),
             /**@type{!{setProperties: !Object, removedProperties: ?Array.<!string>}}*/
-            changedMetadata = {
-                setProperties: {},
-                removedProperties: []
-            },
+            changedMetadata,
             fullName;
 
         // If the operation is an edit (that changes the
         // ODF that will be saved), then update metadata.
         if (op.isEdit) {
-            if (opspec.optype === "UpdateMetadata") {
-                // HACK: Cannot typecast this to OpUpdateMetadata's spec because that would be a cyclic dependency,
-                // therefore forcibly typecast this to advertise the two required properties. Also, deep clone to avoid
-                // unintended modification of the op spec.
-                changedMetadata.setProperties = /**@type{!Object}*/(JSON.parse(JSON.stringify(/**@type{!{setProperties: !Object}}*/(opspec).setProperties)));
-                if (/**@type{!{removedProperties: ?{attributes: !string}}}*/(opspec).removedProperties) {
-                    changedMetadata.removedProperties = /**@type{!{removedProperties: ?{attributes: !string}}}*/(opspec).removedProperties.attributes.split(',');
-                }
-            }
-
             fullName = self.getMember(memberId).getProperties().fullName;
             odfContainer.setMetadata({
                 "dc:creator": fullName,
                 "dc:date": date
             }, null);
-            changedMetadata.setProperties["dc:creator"] = fullName;
-            changedMetadata.setProperties["dc:date"] = date;
+
+            changedMetadata = {
+                setProperties: {
+                    "dc:creator": fullName,
+                    "dc:date": date
+                },
+                removedProperties: []
+            };
 
             // If no previous op was found in this session,
             // then increment meta:editing-cycles by 1.

--- a/webodf/lib/ops/OpUpdateMetadata.js
+++ b/webodf/lib/ops/OpUpdateMetadata.js
@@ -68,6 +68,11 @@ ops.OpUpdateMetadata = function OpUpdateMetadata() {
 
         odfContainer.setMetadata(setProperties, removedPropertiesArray);
 
+        odtDocument.emit(ops.OdtDocument.signalMetadataUpdated, {
+            setProperties: setProperties !== null ? setProperties : {},
+            removedProperties: removedPropertiesArray !== null ? removedPropertiesArray : []
+        });
+
         return true;
     };
 

--- a/webodf/tests/gui/MetadataControllerTests.js
+++ b/webodf/tests/gui/MetadataControllerTests.js
@@ -114,7 +114,21 @@ gui.MetadataControllerTests = function MetadataControllerTests(runner) {
         var changedMetadata = null;
 
         function onMetadataChanged(changes) {
-            changedMetadata = changes;
+            if (changedMetadata === null) {
+                changedMetadata = changes;
+            } else {
+                // merge signal data
+                Object.keys(changes.setProperties).forEach(function (key) {
+                    changedMetadata.setProperties[key] = changes.setProperties[key];
+                });
+                changes.removedProperties.forEach(function (key) {
+                    delete changedMetadata.setProperties[key];
+                    if (changedMetadata.removedProperties.indexOf(key) !== -1) {
+                        changedMetadata.removedProperties.push(key);
+                    }
+                });
+            }
+
             // remove automatic updated metadata
             internalMetadataTagnames.forEach(function(internalTagName) {
                 if (changedMetadata.setProperties && changedMetadata.setProperties[internalTagName]) {
@@ -125,6 +139,10 @@ gui.MetadataControllerTests = function MetadataControllerTests(runner) {
 
         this.getChangedMetadata = function() {
             return changedMetadata;
+        };
+
+        this.reset = function() {
+            changedMetadata = null;
         };
 
         // init
@@ -222,6 +240,7 @@ gui.MetadataControllerTests = function MetadataControllerTests(runner) {
         var metaDataProperties = {};
 
         createOdtDocument(oldData ? tagged(metadataName, oldData) : "");
+        t.metadataChangeListener.reset();
 
         metaDataProperties[metadataName] = newData;
         t.metadataController.setMetadata(metaDataProperties);
@@ -256,6 +275,7 @@ gui.MetadataControllerTests = function MetadataControllerTests(runner) {
      */
     function removeMetaData(metadataName, oldData, shouldBeRemoved) {
         createOdtDocument(oldData ? tagged(metadataName, oldData) : "");
+        t.metadataChangeListener.reset();
 
         t.metadataController.setMetadata(null, [metadataName]);
 


### PR DESCRIPTION
Following initial design there should be multiple different operation sets possible, all working on the same document classes.
So relying on a certain optype and its spec in the code of ops.OdtDocument is conflicting with that.

This patch means that for OpUpdateMetadata there will be now two separate signals emitted. I do not see a problem with that, as this op is not done often.

Ran across this when drafting that other signal-only-after-op-execution-completed PR, still not done.