### PR TITLE
Prevent hyperlink handler for potential dangerous URIs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,8 @@ See also section about WebODF
 
 * Fix wrongly enabled hyperlink tools with no document loaded ([#833](https://github.com/kogmbh/WebODF/pull/833))
 * Prevent Cross-Site Scripting from style names and font names ([#849](https://github.com/kogmbh/WebODF/pull/849)))
-* Avoid badly rendered toolbar element with subsets of tools ([#849](https://github.com/kogmbh/WebODF/pull/855)))
+* Avoid badly rendered toolbar element with subsets of tools ([#855](https://github.com/kogmbh/WebODF/pull/855)))
+* Prevent Cross-Site Scripting from links ([#850](https://github.com/kogmbh/WebODF/pull/850)))
 
 # Changes between 0.5.3 and 0.5.4
 

--- a/webodf/lib/gui/HyperlinkClickHandler.js
+++ b/webodf/lib/gui/HyperlinkClickHandler.js
@@ -115,8 +115,13 @@ gui.HyperlinkClickHandler = function HyperlinkClickHandler(getContainer, keyDown
                 bookmarks[0].scrollIntoView(true);
             }
         } else {
-            // Ask the browser to open the link in a new window.
-            window.open(url);
+            // Ask the browser to open the link in a new window. `javascript` and `data` URIs are disabled for
+            // security reasons.
+            if(/^\s*(javascript|data):/.test(url)) {
+                runtime.log("WARN:", "potentially malicious URL ignored");
+            } else {
+                window.open(url);
+            }
         }
 
         if (e.preventDefault) {


### PR DESCRIPTION
This prevents the user from clicking on URIs starting with `javascript` or `data`. The reason behind this is that this may be used to trick users in executing dangerous JS when viewing an untrusted document. (which is the case in our deployment for ownCloud)

I'm not absolutely happy with that patch for multiple reasons, but I consider it a feasible approach:

1. It uses a blacklisting instead of a whitelisting approach. But when it comes to URI schemes there may be a lot of possible values such as `mailto:foo@bar.com` or `ftp://`. That's why I went with this route instead.
2. I originally wanted to check for `javascript:` instead but this fails due to the JSLint policy which then complains about `lib/gui/HyperlinkClickHandler.js:119:28: error: JavaScript URL.`