### PR TITLE
Support modified/unmodified state with documents

### DIFF
--- a/programs/editor/HOWTO-wodotexteditor.md
+++ b/programs/editor/HOWTO-wodotexteditor.md
@@ -69,6 +69,20 @@ Once the editing should be done, the current state of the document can be retrie
 
 See the example file "localfileeditor.js" how the above can be applied.
 
+To track if the user has edited the document after it was loaded or since it has been synchronized the last time, the editor has a property "documentModified".
+The current state of the document can be set as unmodified by calling
+
+    editor.setDocumentModified(false);
+
+e.g. when the document has been synchronized somewhere. To query if the document is modified call "isDocumentModified()" on the editor object,
+
+    if (editor.isDocumentModified()) {
+        // ask the user if the changes should be discarded
+    }
+
+See the example file "localfileeditor.js" how the above can be applied.
+
+
 ### Examples
 
 There are two example included how to use the editor for inspiration.

--- a/programs/editor/localfileeditor.js
+++ b/programs/editor/localfileeditor.js
@@ -64,12 +64,15 @@ function createEditor() {
             }
         }
         if (files && files.length === 1) {
-            editor.closeDocument(function() {
-                file = files[0];
-                reader = new FileReader();
-                reader.onloadend = onLoadEnd;
-                reader.readAsArrayBuffer(file);
-            });
+            if (!editor.isDocumentModified() ||
+                window.confirm("There are unsaved changes to the file. Do you want to discard them?")) {
+                editor.closeDocument(function() {
+                    file = files[0];
+                    reader = new FileReader();
+                    reader.onloadend = onLoadEnd;
+                    reader.readAsArrayBuffer(file);
+                });
+            }
         } else {
             alert("File could not be opened in this browser.");
         }
@@ -132,6 +135,8 @@ function createEditor() {
                 filename = loadedFilename || "doc.odt",
                 blob = new Blob([data.buffer], {type: mimetype});
             saveAs(blob, filename);
+            // TODO: hm, saveAs could fail or be cancelled
+            editor.setDocumentUnmodified();
         }
 
         editor.getDocumentAsByteArray(saveByteArrayLocally);
@@ -156,6 +161,17 @@ function createEditor() {
         editor.setUserData({
             fullName: "WebODF-Curious",
             color:    "black"
+        });
+
+        window.addEventListener("beforeunload", function (e) {
+            var confirmationMessage = "There are unsaved changes to the file.";
+
+            if (editor.isDocumentModified()) {
+                // Gecko + IE
+                (e || window.event).returnValue = confirmationMessage;
+                // Webkit, Safari, Chrome etc.
+                return confirmationMessage;
+            }
         });
 
         if (docUrl) {

--- a/programs/editor/localfileeditor.js
+++ b/programs/editor/localfileeditor.js
@@ -136,7 +136,7 @@ function createEditor() {
                 blob = new Blob([data.buffer], {type: mimetype});
             saveAs(blob, filename);
             // TODO: hm, saveAs could fail or be cancelled
-            editor.setDocumentUnmodified();
+            editor.setDocumentModified(false);
         }
 
         editor.getDocumentAsByteArray(saveByteArrayLocally);

--- a/programs/editor/revieweditor.js
+++ b/programs/editor/revieweditor.js
@@ -64,12 +64,15 @@ function createReviewEditor() {
             }
         }
         if (files && files.length === 1) {
-            editor.closeDocument(function() {
-                file = files[0];
-                reader = new FileReader();
-                reader.onloadend = onLoadEnd;
-                reader.readAsArrayBuffer(file);
-            });
+            if (!editor.isDocumentModified() ||
+                window.confirm("There are unsaved changes to the file. Do you want to discard them?")) {
+                editor.closeDocument(function() {
+                    file = files[0];
+                    reader = new FileReader();
+                    reader.onloadend = onLoadEnd;
+                    reader.readAsArrayBuffer(file);
+                });
+            }
         } else {
             alert("File could not be opened in this browser.");
         }
@@ -132,6 +135,8 @@ function createReviewEditor() {
                 filename = loadedFilename || "doc.odt",
                 blob = new Blob([data.buffer], {type: mimetype});
             saveAs(blob, filename);
+            // TODO: hm, saveAs could fail or be cancelled
+            editor.setDocumentUnmodified();
         }
 
         editor.getDocumentAsByteArray(saveByteArrayLocally);
@@ -162,6 +167,17 @@ function createReviewEditor() {
         editor.setUserData({
             fullName: "WebODF-Curious",
             color:    "black"
+        });
+
+        window.addEventListener("beforeunload", function (e) {
+            var confirmationMessage = "There are unsaved changes to the file.";
+
+            if (editor.isDocumentModified()) {
+                // Gecko + IE
+                (e || window.event).returnValue = confirmationMessage;
+                // Webkit, Safari, Chrome etc.
+                return confirmationMessage;
+            }
         });
 
         if (docUrl) {

--- a/programs/editor/revieweditor.js
+++ b/programs/editor/revieweditor.js
@@ -136,7 +136,7 @@ function createReviewEditor() {
                 blob = new Blob([data.buffer], {type: mimetype});
             saveAs(blob, filename);
             // TODO: hm, saveAs could fail or be cancelled
-            editor.setDocumentUnmodified();
+            editor.setDocumentModified(false);
         }
 
         editor.getDocumentAsByteArray(saveByteArrayLocally);

--- a/programs/editor/wodotexteditor.js
+++ b/programs/editor/wodotexteditor.js
@@ -149,6 +149,9 @@ var Wodo = Wodo || (function () {
         EVENT_UNKNOWNERROR = "unknownError",
         /** @inner @const
             @type {!string} */
+        EVENT_MODIFIEDCHANGED = "modifiedChanged",
+        /** @inner @const
+            @type {!string} */
         EVENT_METADATACHANGED = "metadataChanged";
 
 
@@ -298,6 +301,7 @@ var Wodo = Wodo || (function () {
             //
             eventNotifier = new core.EventNotifier([
                 EVENT_UNKNOWNERROR,
+                EVENT_MODIFIEDCHANGED,
                 EVENT_METADATACHANGED
             ]);
 
@@ -309,6 +313,14 @@ var Wodo = Wodo || (function () {
          */
         function relayMetadataSignal(changes) {
             eventNotifier.emit(EVENT_METADATACHANGED, changes);
+        }
+
+        /**
+         * @param {!Object} changes
+         * @return {undefined}
+         */
+        function relayModifiedSignal(modified) {
+            eventNotifier.emit(EVENT_MODIFIEDCHANGED, modified);
         }
 
         /**
@@ -337,6 +349,7 @@ var Wodo = Wodo || (function () {
             });
             if (undoRedoEnabled) {
                 editorSession.sessionController.setUndoManager(new gui.TrivialUndoManager());
+                editorSession.sessionController.getUndoManager().subscribe(gui.UndoManager.signalModifiedChanged, relayModifiedSignal);
             }
 
             // Relay any metadata changes to the Editor's consumer as an event
@@ -528,6 +541,37 @@ var Wodo = Wodo || (function () {
         this.getUserData = function() {
             return cloneUserData(userData);
         }
+
+        /**
+         * Sets the current state of the document to be the unmodified state.
+         *
+         * @name TextEditor#setDocumentUnmodified
+         * @function
+         * @return {undefined}
+         */
+        this.setDocumentUnmodified = function() {
+            runtime.assert(editorSession, "editorSession should exist here.");
+
+            if (undoRedoEnabled) {
+                editorSession.sessionController.getUndoManager().setUnmodified();
+            }
+        };
+
+        /**
+         * Returns if the current state of the document matches the unmodified state.
+         * @name TextEditor#isDocumentModified
+         * @function
+         * @return {!boolean}
+         */
+        this.isDocumentModified = function() {
+            runtime.assert(editorSession, "editorSession should exist here.");
+
+            if (undoRedoEnabled) {
+                return editorSession.sessionController.getUndoManager().isModified();
+            }
+
+            return false;
+        };
 
         /**
          * @return {undefined}
@@ -774,6 +818,8 @@ var Wodo = Wodo || (function () {
         // flags
         /** Id of event for an unkown error */
         EVENT_UNKNOWNERROR: EVENT_UNKNOWNERROR,
+        /** Id of event if modified state changes */
+        EVENT_MODIFIEDCHANGED: EVENT_MODIFIEDCHANGED,
         /** Id of event if metadata changes */
         EVENT_METADATACHANGED: EVENT_METADATACHANGED
     };

--- a/programs/editor/wodotexteditor.js
+++ b/programs/editor/wodotexteditor.js
@@ -543,17 +543,22 @@ var Wodo = Wodo || (function () {
         }
 
         /**
-         * Sets the current state of the document to be the unmodified state.
+         * Sets the current state of the document to be either the unmodified state
+         * or a modified state.
+         * If @p modified is @true and the current state was already a modified state,
+         * this call has no effect and also does not remove the unmodified flag
+         * from the state which has it set.
          *
-         * @name TextEditor#setDocumentUnmodified
+         * @name TextEditor#setDocumentModified
          * @function
+         * @param {!boolean} modified
          * @return {undefined}
          */
-        this.setDocumentUnmodified = function() {
+        this.setDocumentModified = function(modified) {
             runtime.assert(editorSession, "editorSession should exist here.");
 
             if (undoRedoEnabled) {
-                editorSession.sessionController.getUndoManager().setUnmodified();
+                editorSession.sessionController.getUndoManager().setModified(modified);
             }
         };
 

--- a/programs/editor/wodotexteditor.js
+++ b/programs/editor/wodotexteditor.js
@@ -149,7 +149,7 @@ var Wodo = Wodo || (function () {
         EVENT_UNKNOWNERROR = "unknownError",
         /** @inner @const
             @type {!string} */
-        EVENT_MODIFIEDCHANGED = "modifiedChanged",
+        EVENT_DOCUMENTMODIFIEDCHANGED = "documentModifiedChanged",
         /** @inner @const
             @type {!string} */
         EVENT_METADATACHANGED = "metadataChanged";
@@ -301,7 +301,7 @@ var Wodo = Wodo || (function () {
             //
             eventNotifier = new core.EventNotifier([
                 EVENT_UNKNOWNERROR,
-                EVENT_MODIFIEDCHANGED,
+                EVENT_DOCUMENTMODIFIEDCHANGED,
                 EVENT_METADATACHANGED
             ]);
 
@@ -349,7 +349,7 @@ var Wodo = Wodo || (function () {
             });
             if (undoRedoEnabled) {
                 editorSession.sessionController.setUndoManager(new gui.TrivialUndoManager());
-                editorSession.sessionController.getUndoManager().subscribe(gui.UndoManager.signalModifiedChanged, relayModifiedSignal);
+                editorSession.sessionController.getUndoManager().subscribe(gui.UndoManager.signalDocumentModifiedChanged, relayModifiedSignal);
             }
 
             // Relay any metadata changes to the Editor's consumer as an event
@@ -558,7 +558,7 @@ var Wodo = Wodo || (function () {
             runtime.assert(editorSession, "editorSession should exist here.");
 
             if (undoRedoEnabled) {
-                editorSession.sessionController.getUndoManager().setModified(modified);
+                editorSession.sessionController.getUndoManager().setDocumentModified(modified);
             }
         };
 
@@ -572,7 +572,7 @@ var Wodo = Wodo || (function () {
             runtime.assert(editorSession, "editorSession should exist here.");
 
             if (undoRedoEnabled) {
-                return editorSession.sessionController.getUndoManager().isModified();
+                return editorSession.sessionController.getUndoManager().isDocumentModified();
             }
 
             return false;
@@ -823,8 +823,8 @@ var Wodo = Wodo || (function () {
         // flags
         /** Id of event for an unkown error */
         EVENT_UNKNOWNERROR: EVENT_UNKNOWNERROR,
-        /** Id of event if modified state changes */
-        EVENT_MODIFIEDCHANGED: EVENT_MODIFIEDCHANGED,
+        /** Id of event if documentModified state changes */
+        EVENT_DOCUMENTMODIFIEDCHANGED: EVENT_DOCUMENTMODIFIEDCHANGED,
         /** Id of event if metadata changes */
         EVENT_METADATACHANGED: EVENT_METADATACHANGED
     };

--- a/webodf/lib/gui/TrivialUndoManager.js
+++ b/webodf/lib/gui/TrivialUndoManager.js
@@ -54,7 +54,7 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
             gui.UndoManager.signalUndoStackChanged,
             gui.UndoManager.signalUndoStateCreated,
             gui.UndoManager.signalUndoStateModified,
-            gui.UndoManager.signalModifiedChanged,
+            gui.UndoManager.signalDocumentModifiedChanged,
             gui.TrivialUndoManager.signalDocumentRootReplaced
         ]),
         undoRules = defaultRules || new gui.UndoStateRules(),
@@ -292,13 +292,13 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
     /**
      * @return {!boolean}
      */
-    this.isModified = isModified;
+    this.isDocumentModified = isModified;
 
     /**
      * @param {!boolean} modified
      * @return {undefined}
      */
-    this.setModified = function(modified) {
+    this.setDocumentModified = function(modified) {
         // current state is already matching the new state?
         if (isModified() === modified) {
             return;
@@ -311,7 +311,7 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
             unmodifiedStateId = currentUndoStateTransition.getNextStateId();
         }
 
-        eventNotifier.emit(gui.UndoManager.signalModifiedChanged, modified);
+        eventNotifier.emit(gui.UndoManager.signalDocumentModifiedChanged, modified);
     };
 
     /**
@@ -420,7 +420,7 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
 
         newModified = isModified();
         if (oldModified !== newModified) {
-            eventNotifier.emit(gui.UndoManager.signalModifiedChanged, newModified);
+            eventNotifier.emit(gui.UndoManager.signalDocumentModifiedChanged, newModified);
         }
     };
 

--- a/webodf/lib/gui/TrivialUndoManager.js
+++ b/webodf/lib/gui/TrivialUndoManager.js
@@ -234,19 +234,26 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
     this.isModified = isModified;
 
     /**
+     * @param {!boolean} modified
      * @return {undefined}
      */
-    this.setUnmodified = function() {
-        // current state is already tagged as unmodified state?
-        if (!isModified()) {
+    this.setModified = function(modified) {
+        // current state is already matching the new state?
+        if (isModified() === modified) {
             return;
         }
 
-        unmodifiedBranch = branch;
-        unmodifiedUndoStatesCount = undoStates.length;
-        unmodifiedLastUndoStateEditOpCount = currentUndoStateEditOpCount();
+        if (modified) {
+            // remove unmodified flag from current state and thus any state
+            // done by setting the branch to a non-existing value, so it will never match
+            unmodifiedBranch = -1;
+        } else {
+            unmodifiedBranch = branch;
+            unmodifiedUndoStatesCount = undoStates.length;
+            unmodifiedLastUndoStateEditOpCount = currentUndoStateEditOpCount();
+        }
 
-        eventNotifier.emit(gui.UndoManager.signalModifiedChanged, false);
+        eventNotifier.emit(gui.UndoManager.signalModifiedChanged, modified);
     };
 
     /**

--- a/webodf/lib/gui/UndoManager.js
+++ b/webodf/lib/gui/UndoManager.js
@@ -110,6 +110,19 @@ gui.UndoManager.prototype.moveBackward = function (states) {"use strict"; };
  */
 gui.UndoManager.prototype.onOperationExecuted = function (op) {"use strict"; };
 
+/**
+ * Returns if the current state matches the unmodified state.
+ * @return {!boolean}
+ */
+gui.UndoManager.prototype.isModified = function () {"use strict"; };
+
+/**
+ * Sets the current state to be the unmodified state.
+ * @return {undefined}
+ */
+gui.UndoManager.prototype.setUnmodified = function() {"use strict"; };
+
 /**@const*/gui.UndoManager.signalUndoStackChanged = "undoStackChanged";
 /**@const*/gui.UndoManager.signalUndoStateCreated = "undoStateCreated";
 /**@const*/gui.UndoManager.signalUndoStateModified = "undoStateModified";
+/**@const*/gui.UndoManager.signalModifiedChanged = "modifiedChanged";

--- a/webodf/lib/gui/UndoManager.js
+++ b/webodf/lib/gui/UndoManager.js
@@ -117,10 +117,12 @@ gui.UndoManager.prototype.onOperationExecuted = function (op) {"use strict"; };
 gui.UndoManager.prototype.isModified = function () {"use strict"; };
 
 /**
- * Sets the current state to be the unmodified state.
+ * Sets the current state of the document to be either the unmodified state
+ * or a modified state.
+ * @param {!boolean} modified
  * @return {undefined}
  */
-gui.UndoManager.prototype.setUnmodified = function() {"use strict"; };
+gui.UndoManager.prototype.setModified = function(modified) {"use strict"; };
 
 /**@const*/gui.UndoManager.signalUndoStackChanged = "undoStackChanged";
 /**@const*/gui.UndoManager.signalUndoStateCreated = "undoStateCreated";

--- a/webodf/lib/gui/UndoManager.js
+++ b/webodf/lib/gui/UndoManager.js
@@ -114,7 +114,7 @@ gui.UndoManager.prototype.onOperationExecuted = function (op) {"use strict"; };
  * Returns if the current state matches the unmodified state.
  * @return {!boolean}
  */
-gui.UndoManager.prototype.isModified = function () {"use strict"; };
+gui.UndoManager.prototype.isDocumentModified = function () {"use strict"; };
 
 /**
  * Sets the current state of the document to be either the unmodified state
@@ -122,9 +122,9 @@ gui.UndoManager.prototype.isModified = function () {"use strict"; };
  * @param {!boolean} modified
  * @return {undefined}
  */
-gui.UndoManager.prototype.setModified = function(modified) {"use strict"; };
+gui.UndoManager.prototype.setDocumentModified = function(modified) {"use strict"; };
 
 /**@const*/gui.UndoManager.signalUndoStackChanged = "undoStackChanged";
 /**@const*/gui.UndoManager.signalUndoStateCreated = "undoStateCreated";
 /**@const*/gui.UndoManager.signalUndoStateModified = "undoStateModified";
-/**@const*/gui.UndoManager.signalModifiedChanged = "modifiedChanged";
+/**@const*/gui.UndoManager.signalDocumentModifiedChanged = "documentModifiedChanged";

--- a/webodf/tests/manifest.json
+++ b/webodf/tests/manifest.json
@@ -111,6 +111,7 @@
         "core.PositionFilterChain",
         "core.UnitTester",
         "gui.TrivialUndoManager",
+        "gui.UndoManager",
         "ops.Document",
         "ops.OpAddCursor",
         "ops.OpInsertText",


### PR DESCRIPTION
When editing a copy of a document in the editor it is useful to know which state of the document in the editor matches the state that has been synched to some storage.
E.g. to know when to warn users on leaving the page that changes will be lost.

For Wodo.TextEditor this API extension is proposed:
```
setDocumentModified(modified:boolean): undefined
isDocumentModified(): boolean
EVENT_DOCUMENTMODIFIEDCHANGED: modified: boolean
```
where `setDocumentModified(true)` would unset the current state from unmodified if it currently is set to, but not clear the unmodified flag from any other document state.

As the UndoManager has direct control about the state, it seemed like a good idea to make the unmodified tracking a responsibility of them and extend the API for this ability, thus demanding implementations to care about that. Not sure yet if that logic can be generalized into a separate utility class, for now the code directly inside TrivialUndoManager was simpler to do at least. For editors without an undomanager a fallback solution is still needed.

- [x] Code draft 
- [x] extend examples
- [x] Unit tests
- [x] document usage in tutorials