### PR TITLE
ViewerJS improvements: support arguments, get mimetype from server or argument

### DIFF
--- a/programs/viewer/PluginLoader.js
+++ b/programs/viewer/PluginLoader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 KO GmbH <copyright@kogmbh.com>
+ * Copyright (C) 2012-2015 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
  * This file is part of WebODF.
@@ -24,49 +24,178 @@
 
 /*global document, window, Viewer, ODFViewerPlugin*/
 
-var viewer;
-
-function loadPlugin(pluginName, callback) {
-    "use strict";
-    var script, style;
-
-    // Load script
-    script = document.createElement('script');
-    script.async = false;
-    script.onload = callback;
-    script.src = pluginName + '.js';
-    script.type = 'text/javascript';
-    document.getElementsByTagName('head')[0].appendChild(script);
-}
-
-function loadDocument(documentUrl) {
+function loadDocument() {
     "use strict";
 
-    var Plugin;
+    var pluginRegistry = [
+        (function() {
+            var odfMimetypes = [
+                'application/vnd.oasis.opendocument.text',
+                'application/vnd.oasis.opendocument.text-flat-xml',
+                'application/vnd.oasis.opendocument.text-template',
+                'application/vnd.oasis.opendocument.presentation',
+                'application/vnd.oasis.opendocument.presentation-flat-xml',
+                'application/vnd.oasis.opendocument.presentation-template',
+                'application/vnd.oasis.opendocument.spreadsheet',
+                'application/vnd.oasis.opendocument.spreadsheet-flat-xml',
+                'application/vnd.oasis.opendocument.spreadsheet-template'];
+            var odfFileExtensions = [
+                'odt',
+                'fodt',
+                'ott',
+                'odp',
+                'fodp',
+                'otp',
+                'ods',
+                'fods',
+                'ots'];
 
-    if (documentUrl) {
-        var extension = documentUrl.split('.').pop();
+            return {
+                supportsMimetype: function(mimetype) {
+                    return (odfMimetypes.indexOf(mimetype) !== -1);
+                },
+                supportsFileExtension: function(extension) {
+                    return (odfFileExtensions.indexOf(extension) !== -1);
+                },
+                path: "./ODFViewerPlugin",
+                getClass: function() { return ODFViewerPlugin; }
+            };
+        }())
+    ];
 
-        switch (extension) {
-        case 'odt':
-        case 'fodt':
-        case 'ott':
-        case 'odp':
-        case 'fodp':
-        case 'otp':
-        case 'ods':
-        case 'fods':
-        case 'ots':
-            loadPlugin('./ODFViewerPlugin', function () {
-                Plugin = ODFViewerPlugin;
-            });
-            break;
-        }
+    function loadPlugin(pluginName, callback) {
+        "use strict";
+        var script, style;
+
+        // Load script
+        script = document.createElement('script');
+        script.async = false;
+        script.onload = callback;
+        script.src = pluginName + '.js';
+        script.type = 'text/javascript';
+        document.getElementsByTagName('head')[0].appendChild(script);
     }
 
+
+    function estimateTypeByHeaderContentType(documentUrl, cb) {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            var mimetype, matchingPluginData;
+            if (xhr.readyState === 4) {
+                if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 0) {
+                    mimetype = xhr.getResponseHeader('content-type');
+
+                    if (mimetype) {
+                        pluginRegistry.some(function(pluginData) {
+                            if (pluginData.supportsMimetype(mimetype)) {
+                                matchingPluginData = pluginData;
+                                console.log('Found plugin by mimetype and xhr head: ' + mimetype);
+                                return true;
+                            }
+                            return false;
+                        });
+                    }
+                }
+                cb(matchingPluginData);
+            }
+        };
+        xhr.open("HEAD", documentUrl, true);
+        xhr.send();
+    }
+
+
+    function doEstimateTypeByFileExtension(extension) {
+        var matchingPluginData;
+
+        pluginRegistry.some(function(pluginData) {
+            if (pluginData.supportsFileExtension(extension)) {
+                matchingPluginData = pluginData;
+                return true;
+            }
+            return false;
+        });
+
+        return matchingPluginData;
+    }
+
+
+    function estimateTypeByFileExtension(extension) {
+        var matchingPluginData = doEstimateTypeByFileExtension(extension)
+
+        if (matchingPluginData) {
+            console.log('Found plugin by parameter type: ' + extension);
+        }
+
+        return matchingPluginData;
+    }
+
+
+    function estimateTypeByFileExtensionFromPath(documentUrl) {
+        // See to get any path from the url and grep what could be a file extension
+        var documentPath = documentUrl.split('?')[0],
+            extension = documentPath.split('.').pop(),
+            matchingPluginData = doEstimateTypeByFileExtension(extension)
+
+        if (matchingPluginData) {
+            console.log('Found plugin by file extension from path: ' + extension);
+        }
+
+        return matchingPluginData;
+    }
+
+
+    function parseSearchParameters(location) {
+        var parameters = {},
+            search = location.search || "?";
+
+        search.substr(1).split('&').forEach(function (q) {
+            // skip empty strings
+            if (!q) {
+                return;
+            }
+            // if there is no '=', have it handled as if given key was set to undefined
+            var s = q.split('=', 2);
+            parameters[decodeURIComponent(s[0])] = decodeURIComponent(s[1]);
+        });
+
+        return parameters;
+    }
+
+
     window.onload = function () {
-        if (Plugin) {
-            viewer = new Viewer(new Plugin());
+        var viewer,
+            documentUrl = document.location.hash.substring(1),
+            parameters = parseSearchParameters(document.location),
+            Plugin;
+
+        if (documentUrl) {
+            // try to guess the title as filename from the location, if not set by parameter
+            if (!parameters.title) {
+                parameters.title = documentUrl.replace(/^.*[\\\/]/, '');
+            }
+
+            parameters.documentUrl = documentUrl;
+
+            // trust the server most
+            estimateTypeByHeaderContentType(documentUrl, function(pluginData) {
+                if (!pluginData) {
+                    if (parameters.type) {
+                        pluginData = estimateTypeByFileExtension(parameters.type);
+                    } else {
+                        // last ressort: try to guess from path
+                        pluginData = estimateTypeByFileExtensionFromPath(documentUrl);
+                    }
+                }
+
+                if (pluginData) {
+                    loadPlugin(pluginData.path, function () {
+                        Plugin = pluginData.getClass();
+                        viewer = new Viewer(new Plugin(), parameters);
+                   });
+                } else {
+                    viewer = new Viewer();
+                }
+            });
         } else {
             viewer = new Viewer();
         }

--- a/programs/viewer/index.html
+++ b/programs/viewer/index.html
@@ -54,7 +54,7 @@ limitations under the License.
              file for a sample.
         <link rel="stylesheet" type="text/css" href="local.css" media="screen"/>
         -->
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"/>
         <link rel="stylesheet" type="text/css" href="viewer.css" media="screen"/>
         <script src="viewer.js" type="text/javascript" charset="utf-8"></script>
         <script src="PluginLoader.js" type="text/javascript" charset="utf-8"></script>

--- a/programs/viewer/index.html
+++ b/programs/viewer/index.html
@@ -59,7 +59,7 @@ limitations under the License.
         <script src="viewer.js" type="text/javascript" charset="utf-8"></script>
         <script src="PluginLoader.js" type="text/javascript" charset="utf-8"></script>
         <script>
-            loadDocument(window.location.hash);
+            loadDocument();
         </script>
     </head>
 

--- a/programs/viewer/index.html
+++ b/programs/viewer/index.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<html dir="ltr" lang="en-US">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
 <!--
   Copyright (C) 2012-2014 KO GmbH <copyright@kogmbh.com>
@@ -45,9 +48,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<html dir="ltr" lang="en-US">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <title>ViewerJS</title>
         <!-- If you want to use custom CSS (@font-face rules, for example) you should uncomment
              the following reference and use a local.css file for that. See the example.local.css

--- a/programs/viewer/viewer.js
+++ b/programs/viewer/viewer.js
@@ -244,10 +244,35 @@ function Viewer(viewerPlugin) {
         delayedRefresh(300);
     }
 
-    
+    function readZoomParameter(zoom) {
+        var validZoomStrings = ["auto", "page-actual", "page-width"],
+            number;
+
+        if (validZoomStrings.indexOf(zoom) !== -1) {
+            return zoom;
+        }
+        number = parseFloat(zoom);
+        if (number && kMinScale <= number && number <= kMaxScale) {
+            return zoom;
+        }
+        return kDefaultScale;
+    }
+
+    function parseSearchParameters(location) {
+        var parameters = {},
+            search = location.search || "?";
+        search.substr(1).split('&').forEach(function (q) {
+            var s = q.split('=', 2);
+            parameters[s[0]] = s[1];
+        });
+        return parameters;
+    }
+
     this.initialize = function () {
         var location = String(document.location),
+            parameters = parseSearchParameters(document.location),
             pos = location.indexOf('#'),
+            initialScale,
             element;
 
         location = location.substr(pos + 1);
@@ -255,6 +280,8 @@ function Viewer(viewerPlugin) {
             console.log('Could not parse file path argument.');
             return;
         }
+
+        initialScale = readZoomParameter(parameters['zoom']);
 
         url = location;
         filename = url.replace(/^.*[\\\/]/, '');
@@ -288,7 +315,7 @@ function Viewer(viewerPlugin) {
             self.showPage(1);
 
             // Set default scale
-            parseScale(kDefaultScale);
+            parseScale(initialScale);
 
             canvasContainer.onscroll = onScroll;
             delayedRefresh();

--- a/programs/viewer/viewer.js
+++ b/programs/viewer/viewer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2014 KO GmbH <copyright@kogmbh.com>
+ * Copyright (C) 2012-2015 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
  * This file is part of WebODF.
@@ -44,7 +44,7 @@
 
 /*global document, window*/
 
-function Viewer(viewerPlugin) {
+function Viewer(viewerPlugin, parameters) {
     "use strict";
 
     var self = this,
@@ -69,7 +69,6 @@ function Viewer(viewerPlugin) {
         dialogOverlay = document.getElementById('dialogOverlay'),
         toolbarRight = document.getElementById('toolbarRight'),
         aboutDialog,
-        filename,
         pages = [],
         currentPage,
         scaleChangeTimer,
@@ -258,37 +257,17 @@ function Viewer(viewerPlugin) {
         return kDefaultScale;
     }
 
-    function parseSearchParameters(location) {
-        var parameters = {},
-            search = location.search || "?";
-        search.substr(1).split('&').forEach(function (q) {
-            var s = q.split('=', 2);
-            parameters[s[0]] = s[1];
-        });
-        return parameters;
-    }
-
     this.initialize = function () {
-        var location = String(document.location),
-            parameters = parseSearchParameters(document.location),
-            pos = location.indexOf('#'),
-            initialScale,
+        var initialScale,
             element;
 
-        location = location.substr(pos + 1);
-        if (pos === -1 || location.length === 0) {
-            console.log('Could not parse file path argument.');
-            return;
-        }
+        initialScale = readZoomParameter(parameters.zoom);
 
-        initialScale = readZoomParameter(parameters['zoom']);
-
-        url = location;
-        filename = url.replace(/^.*[\\\/]/, '');
-        document.title = filename;
+        url = parameters.documentUrl;
+        document.title = parameters.title;
         var documentName = document.getElementById('documentName');
         documentName.innerHTML = "";
-        documentName.appendChild(documentName.ownerDocument.createTextNode(document.title));
+        documentName.appendChild(documentName.ownerDocument.createTextNode(parameters.title));
 
         viewerPlugin.onLoad = function () {
             document.getElementById('pluginVersion').innerHTML = viewerPlugin.getPluginVersion();
@@ -321,7 +300,7 @@ function Viewer(viewerPlugin) {
             delayedRefresh();
         };
 
-        viewerPlugin.initialize(canvasContainer, location);
+        viewerPlugin.initialize(canvasContainer, url);
     };
 
     /**


### PR DESCRIPTION
Having looked through all the open ViewerJS issues, I found a few low hanging fruits that should feed quite some people, so here we go:

To allow a little customization, like preset zooming, I picked up Jos' proposal in https://github.com/kogmbh/ViewerJS/issues/58 to pass some parameters in the search part of the query. This patch starts with support for the arguments
*  "zoom": initial zoom
* "filename": title to display as filename (hm, perhaps better "title" or "name"?)
* "type": type of the file, identified by extension (see below for more about this)

Example:
```
/ViewerJS/index.html?zoom=page-width&type=odp&filename=WebODF%20Presentation#doc-63195
```

Currently the mimetype is "detected" by looking at the end of the path and seeing if there is something like a file extension. Which fails for generated documents or those where the id for the document is not a filename.
This is a problem for many, as can be seen by e.g. https://github.com/kogmbh/ViewerJS/issues/107, https://github.com/kogmbh/ViewerJS/issues/46, https://github.com/kogmbh/ViewerJS/issues/50

So this patch picks up some proposals in the issues and tries to first get the mimetype from the server, and only as fallback from the path provided. Additionally going for the fallback can be overwritten by passing a value in the "type" argument:
 ```
/ViewerJS/index.html?type=odt&filename=filename=Kr%C3%BCger-%C3%9Cbersicht.odt#docs/63195
```
Question: can all usual webservers be expected to support "HEAD" requests? Or is more real-life adaption work needed around the webserver querying?

Follow-up if this is in: also support issue https://github.com/kogmbh/ViewerJS/issues/99