### PR TITLE
Block browser translation service from translating content (wodo-only)

### DIFF
--- a/programs/editor/widgets/fontPicker.js
+++ b/programs/editor/widgets/fontPicker.js
@@ -46,6 +46,11 @@ define("webodf/editor/widgets/fontPicker", [
                     width: '150px'
                 }
             });
+            // prevent browser translation service messing up ids
+            select.domNode.setAttribute("translate", "no");
+            select.domNode.classList.add("notranslate");
+            select.dropDown.domNode.setAttribute("translate", "no");
+            select.dropDown.domNode.classList.add("notranslate");
 
             this.widget = function () {
                 return select;

--- a/programs/editor/widgets/paragraphStyles.js
+++ b/programs/editor/widgets/paragraphStyles.js
@@ -156,6 +156,11 @@ define("webodf/editor/widgets/paragraphStyles", [
                     width: '100px'
                 }
             });
+            // prevent browser translation service messing up ids
+            select.domNode.setAttribute("translate", "no");
+            select.domNode.classList.add("notranslate");
+            select.dropDown.domNode.setAttribute("translate", "no");
+            select.dropDown.domNode.classList.add("notranslate");
 
             populateStyles();
 

--- a/programs/editor/wodocollabtexteditor.js
+++ b/programs/editor/wodocollabtexteditor.js
@@ -540,6 +540,10 @@ var Wodo = Wodo || (function () {
             // to style also all dialogs, which are attached directly to body
             document.body.classList.add("claro");
 
+            // prevent browser translation service messing up internal address system
+            canvasElement.setAttribute("translate", "no");
+            canvasElement.classList.add("notranslate");
+
             // create widgets
             mainContainer = new BorderContainer({}, mainContainerElementId);
 

--- a/programs/editor/wodotexteditor.js
+++ b/programs/editor/wodotexteditor.js
@@ -689,6 +689,11 @@ var Wodo = Wodo || (function () {
             // to style also all dialogs, which are attached directly to body
             document.body.classList.add("claro");
 
+            // prevent browser translation service messing up internal address system
+            // TODO: this should be done more centrally, but where exactly?
+            canvasElement.setAttribute("translate", "no");
+            canvasElement.classList.add("notranslate");
+
             // create widgets
             mainContainer = new BorderContainer({}, mainContainerElementId);
 


### PR DESCRIPTION
As reported in #796, browser translation services mess up the step caches.

The initial proposal was to just tell the user to properly tag the webpage. But then we could just set the proper flags ourselves.

Decided to protect from translation just
* the canvas with the actual document 
* the UI elements with ids of fonts and paragraph styles, as rendered into HTML

The rest of the editor UI might be handy to get translated as well, if a user willingly decides to let the browser translate it.
The content of `<input>` elements does not get translated from what I tested with chromium, that would also be strange. So this patch does not also tag those where document content is displayed/edited in the UI (e.g. with the hyperlinks).

Not sure how the protection of the canvas could be solved in general, as there is no unique entry point for an editor-only canvas. And for display-only a WebODF-deploying dev might want to allow translation of the document content. Or does that mess too much with the ODF structure?

This is at least a first fix that should go in for 0.5.5 IMHO. Can be still improved later.