### PR TITLE
Reduce usage of innerHTML

### DIFF
--- a/webodf/lib/gui/EditInfoHandle.js
+++ b/webodf/lib/gui/EditInfoHandle.js
@@ -32,7 +32,7 @@
 gui.EditInfoHandle = function EditInfoHandle(parentElement) {
     "use strict";
 
-    var /**@type{!Array.<{memberid:string,time:Date}>}*/
+    var /**@type{!Array.<{memberid:!string,time:!Date}>}*/
         edits = [],
         /**@type{!HTMLDivElement}*/
         handle,
@@ -68,7 +68,7 @@ gui.EditInfoHandle = function EditInfoHandle(parentElement) {
     }
 
     /**
-     * @param {!Array.<{memberid:string,time:Date}>} editArray
+     * @param {!Array.<{memberid:!string,time:!Date}>} editArray
      */
     this.setEdits = function (editArray) {
         edits = editArray;

--- a/webodf/lib/gui/EditInfoHandle.js
+++ b/webodf/lib/gui/EditInfoHandle.js
@@ -58,7 +58,7 @@ gui.EditInfoHandle = function EditInfoHandle(parentElement) {
             timeSpan = document.createElementNS(htmlns, 'span');
             timeSpan.className = "editInfoTime";
             timeSpan.setAttributeNS(editinfons, 'editinfo:memberid', edits[i].memberid);
-            timeSpan.innerHTML = edits[i].time;
+            timeSpan.appendChild(document.createTextNode(edits[i].time.toString()));
 
             infoDiv.appendChild(colorSpan);
             infoDiv.appendChild(authorSpan);

--- a/webodf/lib/gui/EditInfoMarker.js
+++ b/webodf/lib/gui/EditInfoMarker.js
@@ -61,21 +61,21 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
 
     /**
      * Stops the specified timer
-     * @param {number} timerId
+     * @param {!number} timerId
      */
     function deleteDecay(timerId) {
         runtime.clearTimeout(timerId);
     }
 
     /**
-     * @param {string} memberid
+     * @param {!string} memberid
      */
     function setLastAuthor(memberid) {
         marker.setAttributeNS(editinfons, 'editinfo:memberid', memberid);
     }
 
     /**
-     * @param {string} memberid
+     * @param {!string} memberid
      * @param {!Date} timestamp
      */
     this.addEdit = function (memberid, timestamp) {

--- a/webodf/lib/gui/SessionView.js
+++ b/webodf/lib/gui/SessionView.js
@@ -420,7 +420,7 @@ gui.SessionViewOptions = function () {
                 localMember;
 
             // TODO: Move such handling into AnnotationViewManager
-            if (annotationConstraintStyles.innerHTML !== "") {
+            if (annotationConstraintStyles.hasChildNodes()) {
                 annotationConstraintStyles.innerHTML = "";
             }
 

--- a/webodf/lib/ops/EditInfo.js
+++ b/webodf/lib/ops/EditInfo.js
@@ -34,14 +34,14 @@ ops.EditInfo = function EditInfo(container, odtDocument) {
     "use strict";
     var /**@type {!Element}*/
         editInfoNode,
-        /**@type {!Object.<string,{time:Date}>}*/
+        /**@type {!Object.<!string,{time:!Date}>}*/
         editHistory = {};
 
     /**
-     * @return {!Array.<{memberid:string,time:Date}>}
+     * @return {!Array.<{memberid:!string,time:!Date}>}
      */
     function sortEdits() {
-        var /**@type {!Array.<{memberid:string,time:Date}>}*/
+        var /**@type {!Array.<{memberid:!string,time:!Date}>}*/
             arr = [],
             /**@type{string}*/
             memberid;
@@ -76,7 +76,7 @@ ops.EditInfo = function EditInfo(container, odtDocument) {
     };
 
     /**
-     * @return {!Object.<string,{time:Date}>}
+     * @return {!Object.<!string,{time:!Date}>}
      */
     this.getEdits = function () {
         return editHistory;
@@ -84,7 +84,7 @@ ops.EditInfo = function EditInfo(container, odtDocument) {
 
     /**
      * Returns the sorted list of memberid/time pairs, with oldest first.
-     * @return {!Array.<{memberid:string,time:Date}>}
+     * @return {!Array.<{memberid:!string,time:!Date}>}
      */
     this.getSortedEdits = function () {
         return sortEdits();


### PR DESCRIPTION
After this PR only two kinds of `innerHTML` usages are left:
* in runtime.log, see #869 for the related TODO
* used for clearing an element from all child nodes, `element.innerHTML = "";`

Not sure if the latter should be also replaced, most places on the internet hint this is faster than a loop (and of course is also less code :smiling_imp: ). What do you think? Remove any `innerHTML` to prevent people getting an idea of using it for something else, or being okay with that special usecase?
This PR votes for the latter. But you might have a different idea, so please argue.