### PR TITLE
Improve code around annotations a little + bug fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fix breaking all empty annotations on merging the paragraph they are contained in with the one before ([#877](https://github.com/kogmbh/WebODF/pull/877)))
+* Fix error message popup on deleting an annotation starting at the end of a paragraph or styled range ([#880](https://github.com/kogmbh/WebODF/pull/880)))
 
 ### Improvements
 

--- a/webodf/lib/gui/AnnotationViewManager.js
+++ b/webodf/lib/gui/AnnotationViewManager.js
@@ -243,6 +243,8 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
             } else {
                 annotationNote.style.top = '0px';
             }
+        } else {
+            annotationNote.style.top = '0px';
         }
 
         connectorAngular.style.left = connectorHorizontal.getBoundingClientRect().width / zoomLevel + 'px';

--- a/webodf/lib/gui/AnnotationViewManager.js
+++ b/webodf/lib/gui/AnnotationViewManager.js
@@ -385,6 +385,7 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
             showAnnotationsPane(false);
         }
     }
+    this.forgetAnnotation = forgetAnnotation;
 
     /**
      * Untracks, unwraps, and unhighlights all annotations

--- a/webodf/lib/gui/AnnotationViewManager.js
+++ b/webodf/lib/gui/AnnotationViewManager.js
@@ -341,26 +341,33 @@ gui.AnnotationViewManager = function AnnotationViewManager(canvas, odfFragment, 
     this.getMinimumHeightForAnnotationPane = getMinimumHeightForAnnotationPane;
 
     /**
-     * Adds an annotation to track, and wraps and highlights it
-     * @param {!odf.AnnotationElement} annotation
+     * Adds annotations to track, and wraps and highlights them
+     * @param {!Array.<!odf.AnnotationElement>} annotationElements
      * @return {undefined}
      */
-    function addAnnotation(annotation) {
+    function addAnnotations(annotationElements) {
+        if (annotationElements.length === 0) {
+            return;
+        }
+
         showAnnotationsPane(true);
 
-        // TODO: make use of the fact that current list is already sorted
-        // instead just iterate over the list until the right index to insert is found
-        annotations.push(annotation);
+        annotationElements.forEach(function (annotation) {
+            // TODO: make use of the fact that current list is already sorted
+            // instead just iterate over the list until the right index to insert is found
+            annotations.push(annotation);
+
+            wrapAnnotation(annotation);
+            if (annotation.annotationEndElement) {
+                highlightAnnotation(annotation);
+            }
+        });
 
         sortAnnotations();
 
-        wrapAnnotation(annotation);
-        if (annotation.annotationEndElement) {
-            highlightAnnotation(annotation);
-        }
         rerenderAnnotations();
     }
-    this.addAnnotation = addAnnotation;
+    this.addAnnotations = addAnnotations;
 
     /**
      * Unhighlights, unwraps, and ejects an annotation from the tracking

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1291,12 +1291,13 @@
         };
 
         /**
-         * Stops annotations and unwraps it
+         * Stops an annotation and unwraps it
+         * @param {!odf.AnnotationElement} annotation
          * @return {undefined}
          */
-        this.forgetAnnotations = function () {
+        this.forgetAnnotation = function (annotation) {
             if (annotationViewManager) {
-                annotationViewManager.forgetAnnotations();
+                annotationViewManager.forgetAnnotation(annotation);
                 fixContainerSize();
             }
         };

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1047,22 +1047,13 @@
         }
 
         /**
-        * Wraps all annotations and renders them using the Annotation View Manager.
-        * @param {!Element} odffragment
-        * @return {undefined}
-        */
-        function modifyAnnotations(odffragment) {
-            var annotationNodes = /**@type{!Array.<!odf.AnnotationElement>}*/(domUtils.getElementsByTagNameNS(odffragment, officens, 'annotation'));
-
-            annotationViewManager.addAnnotations(annotationNodes);
-        }
-
-        /**
          * This should create an annotations pane if non existent, and then populate it with annotations
          * If annotations are disallowed, it should remove the pane and all annotations
          * @param {!odf.ODFDocumentElement} odfnode
          */
         function handleAnnotations(odfnode) {
+            var annotationNodes;
+
             if (allowAnnotations) {
                 if (!annotationsPane.parentNode) {
                     sizer.appendChild(annotationsPane);
@@ -1071,7 +1062,9 @@
                     annotationViewManager.forgetAnnotations();
                 }
                 annotationViewManager = new gui.AnnotationViewManager(self, odfnode.body, annotationsPane, showAnnotationRemoveButton);
-                modifyAnnotations(odfnode.body);
+                annotationNodes = /**@type{!Array.<!odf.AnnotationElement>}*/(domUtils.getElementsByTagNameNS(odfnode.body, officens, 'annotation'));
+                annotationViewManager.addAnnotations(annotationNodes);
+
                 fixContainerSize();
             } else {
                 if (annotationsPane.parentNode) {

--- a/webodf/lib/odf/OdfCanvas.js
+++ b/webodf/lib/odf/OdfCanvas.js
@@ -1054,8 +1054,7 @@
         function modifyAnnotations(odffragment) {
             var annotationNodes = /**@type{!Array.<!odf.AnnotationElement>}*/(domUtils.getElementsByTagNameNS(odffragment, officens, 'annotation'));
 
-            annotationNodes.forEach(annotationViewManager.addAnnotation);
-            annotationViewManager.rerenderAnnotations();
+            annotationViewManager.addAnnotations(annotationNodes);
         }
 
         /**
@@ -1286,7 +1285,7 @@
          */
         this.addAnnotation = function (annotation) {
             if (annotationViewManager) {
-                annotationViewManager.addAnnotation(annotation);
+                annotationViewManager.addAnnotations([annotation]);
                 fixContainerSize();
             }
         };

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -119,6 +119,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         }
         initialDoc = rootElement.cloneNode(true);
         odfCanvas.refreshAnnotations();
+        // workaround AnnotationViewManager not fixing up cursor positions after creating the highlighting
+        self.fixCursorPositions();
         return initialDoc;
     };
 

--- a/webodf/lib/ops/OpRemoveAnnotation.js
+++ b/webodf/lib/ops/OpRemoveAnnotation.js
@@ -92,8 +92,7 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
         // The specified position is the first walkable step in the annotation. The position is always just before the first point of change
         odtDocument.emit(ops.OdtDocument.signalStepsRemoved, {position: position > 0 ? position - 1 : position});
 
-        odtDocument.getOdfCanvas().refreshAnnotations();
-        // workaround AnnotationViewManager not fixing up cursor positions after creating the highlighting
+        odtDocument.getOdfCanvas().rerenderAnnotations();
         odtDocument.fixCursorPositions();
         return true;
     };

--- a/webodf/lib/ops/OpRemoveAnnotation.js
+++ b/webodf/lib/ops/OpRemoveAnnotation.js
@@ -72,7 +72,7 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
         annotationEnd = annotationNode.annotationEndElement;
 
         // Untrack and unwrap annotation
-        odtDocument.getOdfCanvas().forgetAnnotations();
+        odtDocument.getOdfCanvas().forgetAnnotation(annotationNode);
 
         /**
          * @param {!Node} node

--- a/webodf/lib/ops/OpRemoveAnnotation.js
+++ b/webodf/lib/ops/OpRemoveAnnotation.js
@@ -92,8 +92,9 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
         // The specified position is the first walkable step in the annotation. The position is always just before the first point of change
         odtDocument.emit(ops.OdtDocument.signalStepsRemoved, {position: position > 0 ? position - 1 : position});
 
-        odtDocument.fixCursorPositions();
         odtDocument.getOdfCanvas().refreshAnnotations();
+        // workaround AnnotationViewManager not fixing up cursor positions after creating the highlighting
+        odtDocument.fixCursorPositions();
         return true;
     };
 


### PR DESCRIPTION
Thanks to Bella some issue with current annotation code became more obvious to me, although it partially was already reported in #830 (whose proposed workaround is also picked up in this PR).

As nicely described in https://github.com/kogmbh/WebODF/pull/830#issuecomment-56458622 (thanks @peitschie) adding the highlighting with the cursor at the end of a highlighted area will put the cursor in a non-step position. This happens on all codepaths ending in `highlightAnnotation()` method in `AnnotationViewManager`, which are `AWM.addAnnotations(...)` and `AVM.rehighlightAnnotations()`.

I agree that `AnnotationViewManager` needs some rethinking to fit the other view deps (or the highlighting code an improvement to not push cursors in non-step positions, which might be non-trivial, or even better we get global cursors one day!).

Meanwhile... let's make sure any call to `AWM.addAnnotations(...)` and `AVM.rehighlightAnnotations()` is followed by a `fixCursorPositions()` call.

And to make this PR some more fun to read, there are also two improvements, one to add annotations in batches and the other to change OpRemoveAnnotation to not drop markup and highlighting for all annotations and then redo them, but only for the one annotation that is to be removed.