### PR TITLE
Document review mode of Wodo.TextEditor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@
 ## Wodo.TextEditor
 See also section about WebODF
 
+### Improvements
+
+* Add a "review" modus where users can add, edit and remove own annotations, but not modify the actual document content ([#883](https://github.com/kogmbh/WebODF/pull/883)))
+
 
 # Changes between 0.5.5 and 0.5.6
 

--- a/programs/editor/CMakeLists.txt
+++ b/programs/editor/CMakeLists.txt
@@ -17,6 +17,8 @@ SET(ALONE_EDITOR_EXAMPLE_FILES
     FileSaver.js
     localfileeditor.js
     localeditor.html
+    revieweditor.js
+    revieweditor.html
     texteditor.html
     welcome.odt
 )

--- a/programs/editor/HOWTO-wodotexteditor.md
+++ b/programs/editor/HOWTO-wodotexteditor.md
@@ -6,7 +6,7 @@ The Wodo.TextEditor component needs to be included in webpages served by a webse
 
 ## Creating the Editor
 
-The file which needs to be included to create a Wodo.TextEditor is "wodotexteditor.js".
+The file which needs to be included to create a Wodo.TextEditor is `wodotexteditor.js`.
 
     <head>
     <!-- ... -->
@@ -54,9 +54,9 @@ An instance of the editor is created in JavaScript by calling `Wodo.createTextEd
     // ...
     </script>
 
-See the example file "texteditor.html" how the above can be applied.
+See the example file [`texteditor.html`](texteditor.html) how the above can be applied.
 
-Once the editing should be done, the current state of the document can be retrieved from the editor by calling "editor.getDocumentAsByteArray()":
+Once the editing should be done, the current state of the document can be retrieved from the editor by calling `editor.getDocumentAsByteArray()`:
 
     editor.getDocumentAsByteArray(function (err, odtFileAsByteArray) {
         if (err) {
@@ -67,20 +67,20 @@ Once the editing should be done, the current state of the document can be retrie
         // now do something with odtFileAsByteArray (is of type Uint8Array)
     });
 
-See the example file "localfileeditor.js" how the above can be applied.
+See the example file [`localfileeditor.js`](localfileeditor.js) how the above can be applied.
 
 To track if the user has edited the document after it was loaded or since it has been synchronized the last time, the editor has a property "documentModified".
 The current state of the document can be set as unmodified by calling
 
     editor.setDocumentModified(false);
 
-e.g. when the document has been synchronized somewhere. To query if the document is modified call "isDocumentModified()" on the editor object,
+e.g. when the document has been synchronized somewhere. To query if the document is modified call `isDocumentModified()` on the editor object,
 
     if (editor.isDocumentModified()) {
         // ask the user if the changes should be discarded
     }
 
-See the example file "localfileeditor.js" how the above can be applied.
+See the example file [`localfileeditor.js`](localfileeditor.js) how the above can be applied.
 
 When calling `Wodo.createTextEditor()`, the second parameter allows to configure the editor. See the included API dox for the possible parameters.
 
@@ -91,22 +91,22 @@ For inspiration there are three examples included how to use the Wodo.TextEditor
 
 #### Simple Editor
 
-The file "texteditor.html" holds a very simple example of creating an editor and loading a given file into it, so that it can be edited.
+The file [`texteditor.html`](texteditor.html) holds a very simple example of creating an editor and loading a given file into it, so that it can be edited.
 It does not deal with getting the result and storing it somewhere.
 
 #### Editor which lets user edit files from local filesystem
 
-The file "localeditor.html" extends the simple editor example above by adding two things:
+The file [`localeditor.html`](localeditor.html) extends the simple editor example above by adding two things:
 support for loading files from the local filesystem into the editor and support for storing the current state of the edited document using the "saveAs" feature of browsers.
 
-The example consists of the files "localfileeditor.js" and "localeditor.html". Additionally it uses "FileSaver.js", which is a polyfill for browsers not yet supporting "saveAs".
+The example consists of the files [`localfileeditor.js`](localfileeditor.js) and [`localeditor.html`](localeditor.html). Additionally it uses [`FileSaver.js`](FileSaver.js), which is a polyfill for browsers not yet supporting "saveAs".
 
 #### Editor which lets user review files from local filesystem
 
-The file "revieweditor.html" is a variant of the editor for files of the local filesystem:
+The file [`revieweditor.html`](revieweditor.html) is a variant of the editor for files of the local filesystem:
 it sets the editing modus to "review", which limits the user to only add, edit and remove own annotations, but not change anything else in the document.
 
-The example consists of the files "revieweditor.js" and "revieweditor.html". Additionally it uses "FileSaver.js", which is a polyfill for browsers not yet supporting "saveAs".
+The example consists of the files [`revieweditor.js`](revieweditor.js) and [`revieweditor.html`](revieweditor.html). Additionally it uses [`FileSaver.js`](FileSaver.js), which is a polyfill for browsers not yet supporting "saveAs".
 
 
 ## External Resources
@@ -119,9 +119,9 @@ The Wodo.TextEditor currently supports the central serving of fonts.
 
 ### Fonts
 
-Font files on the server are registered to the Wodo.TextEditor by listing them in a CSS file. Each font is registered with a normal "@font-face" CSS rule.
-The file is name "fonts.css" and placed in the subdirectory "fonts" of the "resources" directory. 
-This file will be automatically read by the Wodo.TextEditor. The font files can be put whereever it suits, as long as their location is correctly given in "fonts.css".
+Font files on the server are registered to the Wodo.TextEditor by listing them in a CSS file. Each font is registered with a normal `@font-face` CSS rule.
+The file is name `fonts.css` and placed in the subdirectory `fonts` of the `resources` directory.
+This file will be automatically read by the Wodo.TextEditor. The font files can be put whereever it suits, as long as their location is correctly given in `fonts.css`.
 
 It surely makes sense to place the fonts into the same directory like "fonts.css", unless also used for other purposes.
 (TODO: instead of a shared "resources" path perhaps there should be an entry just for fonts/fonts.css)
@@ -129,10 +129,10 @@ It surely makes sense to place the fonts into the same directory like "fonts.css
 
 Example:
 
-The Wodo.TextEditor installation is in the path "/wodotexteditor" of the webserver. This requires that the fonts files are listed in
-"/wodotexteditor/resources/fonts/fonts.css".
-There is a font with the font-family name "Gentium Basic" in file name "GenBasR.ttf". The file is placed in "/wodotexteditor/resources/fonts".
-So it will be listed in "fonts.css" as
+The Wodo.TextEditor installation is in the path `/wodotexteditor` of the webserver. This requires that the fonts files are listed in
+`/wodotexteditor/resources/fonts/fonts.css`.
+There is a font with the font-family name "Gentium Basic" in file name `GenBasR.ttf`. The file is placed in `/wodotexteditor/resources/fonts`.
+So it will be listed in `fonts.css` as
 
     @font-face {
         font-family: "Gentium Basic";

--- a/programs/editor/HOWTO-wodotexteditor.md
+++ b/programs/editor/HOWTO-wodotexteditor.md
@@ -26,7 +26,7 @@ In the body of the HTML there needs to be set a div element which should hold th
     <!-- ... -->
     </body>
 
-An instance of the editor is created in JavaScript by calling "Wodo.createTextEditor()":
+An instance of the editor is created in JavaScript by calling `Wodo.createTextEditor()`:
 
     <script type="text/javascript">
     // ...
@@ -82,10 +82,12 @@ e.g. when the document has been synchronized somewhere. To query if the document
 
 See the example file "localfileeditor.js" how the above can be applied.
 
+When calling `Wodo.createTextEditor()`, the second parameter allows to configure the editor. See the included API dox for the possible parameters.
+
 
 ### Examples
 
-There are two example included how to use the editor for inspiration.
+For inspiration there are three examples included how to use the Wodo.TextEditor component.
 
 #### Simple Editor
 
@@ -98,6 +100,13 @@ The file "localeditor.html" extends the simple editor example above by adding tw
 support for loading files from the local filesystem into the editor and support for storing the current state of the edited document using the "saveAs" feature of browsers.
 
 The example consists of the files "localfileeditor.js" and "localeditor.html". Additionally it uses "FileSaver.js", which is a polyfill for browsers not yet supporting "saveAs".
+
+#### Editor which lets user review files from local filesystem
+
+The file "revieweditor.html" is a variant of the editor for files of the local filesystem:
+it sets the editing modus to "review", which limits the user to only add, edit and remove own annotations, but not change anything else in the document.
+
+The example consists of the files "revieweditor.js" and "revieweditor.html". Additionally it uses "FileSaver.js", which is a polyfill for browsers not yet supporting "saveAs".
 
 
 ## External Resources

--- a/programs/editor/revieweditor.js
+++ b/programs/editor/revieweditor.js
@@ -149,13 +149,8 @@ function createReviewEditor() {
     editorOptions = {
         loadCallback: load,
         saveCallback: save,
-        allFeaturesEnabled: true,
-        reviewModeEnabled: true,
-        directParagraphStylingEnabled: false,
-        hyperlinkEditingEnabled: false,
-        imageEditingEnabled: false,
-        paragraphStyleSelectingEnabled: false,
-        paragraphStyleEditingEnabled: false
+        modus: Wodo.MODUS_REVIEW,
+        allFeaturesEnabled: true
     };
 
     function onEditorCreated(err, e) {
@@ -169,7 +164,7 @@ function createReviewEditor() {
 
         editor = e;
         editor.setUserData({
-            fullName: "WebODF-Curious",
+            fullName: "Curious WebODF-Reviewer",
             color:    "black"
         });
 

--- a/programs/editor/wodotexteditor.js
+++ b/programs/editor/wodotexteditor.js
@@ -130,6 +130,12 @@ window.Wodo = window.Wodo || (function () {
         BorderContainer, ContentPane, FullWindowZoomHelper, EditorSession, Tools,
         /** @inner @const
             @type{!string} */
+        MODUS_FULLEDITING = "fullediting",
+        /** @inner @const
+            @type{!string} */
+        MODUS_REVIEW = "review",
+        /** @inner @const
+            @type{!string} */
         EVENT_UNKNOWNERROR = "unknownError",
         /** @inner @const
             @type {!string} */
@@ -291,13 +297,13 @@ window.Wodo = window.Wodo || (function () {
             downloadOdtFile = editorOptions.downloadCallback,
             close =       editorOptions.closeCallback,
             //
+            reviewModeEnabled = (editorOptions.modus === MODUS_REVIEW),
             directTextStylingEnabled = isEnabled(editorOptions.directTextStylingEnabled),
             directParagraphStylingEnabled = isEnabled(editorOptions.directParagraphStylingEnabled),
-            paragraphStyleSelectingEnabled = isEnabled(editorOptions.paragraphStyleSelectingEnabled),
-            paragraphStyleEditingEnabled = isEnabled(editorOptions.paragraphStyleEditingEnabled),
-            imageEditingEnabled = isEnabled(editorOptions.imageEditingEnabled),
+            paragraphStyleSelectingEnabled = (!reviewModeEnabled) && isEnabled(editorOptions.paragraphStyleSelectingEnabled),
+            paragraphStyleEditingEnabled =   (!reviewModeEnabled) && isEnabled(editorOptions.paragraphStyleEditingEnabled),
+            imageEditingEnabled =            (!reviewModeEnabled) && isEnabled(editorOptions.imageEditingEnabled),
             hyperlinkEditingEnabled = isEnabled(editorOptions.hyperlinkEditingEnabled),
-            reviewModeEnabled = Boolean(editorOptions.reviewModeEnabled), // needs to be explicitly enabled
             annotationsEnabled = reviewModeEnabled || isEnabled(editorOptions.annotationsEnabled),
             undoRedoEnabled = isEnabled(editorOptions.undoRedoEnabled),
             zoomingEnabled = isEnabled(editorOptions.zoomingEnabled),
@@ -784,6 +790,7 @@ window.Wodo = window.Wodo || (function () {
      * @function
      * @param {!string} editorContainerElementId id of the existing div element which will contain the editor (should be empty before)
      * @param editorOptions options to configure the features of the editor. All entries are optional
+     * @param [editorOptions.modus=Wodo.MODUS_FULLEDITING] set the editing modus. Current options: Wodo.MODUS_FULLEDITING, Wodo.MODUS_REVIEW
      * @param [editorOptions.loadCallback] parameter-less callback method, adds a "Load" button to the toolbar which triggers this method
      * @param [editorOptions.saveCallback] parameter-less callback method, adds a "Save" button to the toolbar which triggers this method
      * @param [editorOptions.saveAsCallback] parameter-less callback method, adds a "Save as" button to the toolbar which triggers this method
@@ -836,6 +843,10 @@ window.Wodo = window.Wodo || (function () {
     return {
         createTextEditor: createTextEditor,
         // flags
+        /** Id of full editing modus */
+        MODUS_FULLEDITING: MODUS_FULLEDITING,
+        /** Id of review modus */
+        MODUS_REVIEW: MODUS_REVIEW,
         /** Id of event for an unkown error */
         EVENT_UNKNOWNERROR: EVENT_UNKNOWNERROR,
         /** Id of event if documentModified state changes */


### PR DESCRIPTION
Implemented a year ago and used since then e.g. for http://webodf.org/about/features/annotation-demo.html, the review mode feature of Wodo.TextEditor has not yet been really promoted.

Let's change that and document the feature officially in the API of Wodo.TextEditor (especially now that annotation editing got some more bugs fixed and is bellatested (tm)).

Originally the plan was to have just another flag "reviewModeEnabled". Never been really happy about that, e.g. could be seen by its handling that it is not a normal flag.
So I propose to introduce the concept of modes, with "fullediting" and "review" for now. This might also be closer to user ideas/concepts.
Still, further suggestions here welcome, not really settled on that.

Documentation still could be much better, but this PR is at least an improvement to the current situation.

Fixes #686