### PR TITLE
Disable custom buttons save/saveAs/close/download when there is no session

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,12 @@
+# Changes between 0.5.7 and 0.5.8
+
+## Wodo.TextEditor
+
+### Fixes
+
+* Disable custom buttons save/saveAs/close/download when there is no session ([#893](https://github.com/kogmbh/WebODF/pull/893))
+
+
 # Changes between 0.5.6 and 0.5.7
 
 ## WebODF

--- a/programs/editor/Tools.js
+++ b/programs/editor/Tools.js
@@ -105,9 +105,12 @@ define("webodf/editor/Tools", [
                 sessionSubscribers.forEach(function (subscriber) {
                     subscriber.setEditorSession(editorSession);
                 });
-                if (formatMenuButton) {
-                    formatMenuButton.setAttribute('disabled', !editorSession);
-                }
+
+                [saveButton, saveAsButton, downloadButton, closeButton, formatMenuButton].forEach(function (button) {
+                    if (button) {
+                        button.setAttribute('disabled', !editorSession);
+                    }
+                });
             }
 
             this.setEditorSession = setEditorSession;
@@ -171,6 +174,7 @@ define("webodf/editor/Tools", [
                     saveButton = new Button({
                         label: tr('Save'),
                         showLabel: false,
+                        disabled: true,
                         iconClass: 'dijitEditorIcon dijitEditorIconSave',
                         onClick: function () {
                             saveOdtFile();
@@ -185,6 +189,7 @@ define("webodf/editor/Tools", [
                     saveAsButton = new Button({
                         label: tr('Save as...'),
                         showLabel: false,
+                        disabled: true,
                         iconClass: 'webodfeditor-dijitSaveAsIcon',
                         onClick: function () {
                             saveAsOdtFile();
@@ -199,6 +204,7 @@ define("webodf/editor/Tools", [
                     downloadButton = new Button({
                         label: tr('Download'),
                         showLabel: true,
+                        disabled: true,
                         style: {
                             float: 'right'
                         },
@@ -267,6 +273,7 @@ define("webodf/editor/Tools", [
                     closeButton = new Button({
                         label: tr('Close'),
                         showLabel: false,
+                        disabled: true,
                         iconClass: 'dijitEditorIcon dijitEditorIconCancel',
                         style: {
                             float: 'right'


### PR DESCRIPTION
Makes at least sense for all use cases I know currently.

Future versions of Wodo UI (as planned with closure lib) should give more control of those buttons to the developers, of course. But for now this is a small but useful fix with the current simple support for those custom buttons.