### PR TITLE
Changed check for responseBody in xmlHttpRequest object, because IE<=…

### DIFF
--- a/webodf/lib/runtime.js
+++ b/webodf/lib/runtime.js
@@ -569,7 +569,7 @@ function BrowserRuntime() {
                     data = String(xhr.response);
                 }
             } else if (encoding === "binary") {
-                if (xhr.responseBody !== null
+                if (xhr.responseBody !== null && typeof xhr.responseBody !== 'unknown'
                         && String(typeof VBArray) !== "undefined") {
                     // fallback for IE <= 10
                     a = (new VBArray(xhr.responseBody)).toArray();


### PR DESCRIPTION
…10 does not return null.

I had some problems with the webodf script in IE10. While debugging I found that xhr.responseBody is not set to null by IE10 (as your script seems to assume), but is set to an empty "unknown" type.