### PR TITLE
Mention Wodo.CollabTextEditor in READMEs

### DIFF
--- a/README-Products.md
+++ b/README-Products.md
@@ -32,6 +32,23 @@ Unzip it there and read the included HOWTO.md file.
 See the online demo on [webodf.org/demo](http://webodf.org/demo) and download the latest officially released version from the [WebODF homepage](http://webodf.org/download).
 
 
+### Wodo.CollabTextEditor component
+
+For those who want to get an OpenDocument Text editor for collaborative editing in their HTML5 app, the component Wodo.CollabTextEditor is a good choice.
+
+There is currently no documentation for it, besides what is in the code. Wodo.CollabTextEditor is not a complete solution itself, but has some abstraction layers which have to be implemented by adapters to the respective server systems. See the demo file ["splitscreeneditor.js"](programs/editor/splitscreeneditor.js) for an example application by a client-side server with an example adapter.
+This product bundles a subdirectory with all files belonging to the component in one zip file.
+
+With a prepared setup for building, you execute this command:
+
+    make product-wodocollabtexteditor
+
+It creates a file "wodocollabtexteditor-x.y.z.zip", which can be copied and used on a system where you want to develop using the component.
+Unzip it there and move the subdirectory "wodo" to your deployment.
+
+Download the latest officially released version from the [WebODF homepage](http://webodf.org/download).
+
+
 ### Firefox Add-on ODF Viewer
 
 This Firefox add-on enables to view files in the OpenDocument format directly in your Firefox browser, without installing a big office suite.

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ For more details about preparing the build of webodf.js , e.g. on Windows or OSX
 
 This repository not only contains code for the library webodf.js, but also a few products based on it. Here is the complete list:
 
-build target             | output location (in build/)           | description | download/packages
--------------------------|---------------------------------------|---------------|-----
-webodf.js-target         | webodf/webodf.js                      | the library                        | (see product-library)
-product-library          | webodf.js-x.y.z.zip                   | zip file with library and API docs | [WebODF homepage](http://webodf.org/download)
-product-wodotexteditor   | wodotexteditor-x.y.z.zip              | simple to use editor component     | [WebODF homepage](http://webodf.org/download)
-product-firefoxextension | firefox-extension-odfviewer-x.y.z.xpi | ODF viewer Firefox add-on          | [Mozilla's Add-on website](https://addons.mozilla.org/firefox/addon/webodf/)
+build target                 | output location (in build/)           | description                        | download/packages
+-----------------------------|---------------------------------------|------------------------------------|-----
+webodf.js-target             | webodf/webodf.js                      | the library                        | (see product-library)
+product-library              | webodf.js-x.y.z.zip                   | zip file with library and API docs | [WebODF homepage](http://webodf.org/download)
+product-wodotexteditor       | wodotexteditor-x.y.z.zip              | simple to use editor component     | [WebODF homepage](http://webodf.org/download)
+product-wodocollabtexteditor | wodocollabtexteditor-x.y.z.zip        | collaborative editor component     | [WebODF homepage](http://webodf.org/download)
+product-firefoxextension     | firefox-extension-odfviewer-x.y.z.xpi | ODF viewer Firefox add-on          | [Mozilla's Add-on website](https://addons.mozilla.org/firefox/addon/webodf/)
 
 ("x.y.z" is a placeholder for the actual version number)
 


### PR DESCRIPTION
Given that Wodo.CollabTextEditor is already used in some products (with two to be open-sourced very, very soon :) ), it makes sense to officially document it now.

Not really happy yet with its state, but it works good enough for those products and currently noone has plans to change the API some more for the time being.

I would also propose to start releasing Wodo.CollabTextEditor officially with new WebODF versions, like already done with Wodo.TextEditor. For now I would just upload a preview release to webodf.org/download (as referenced by those to be open-sourced products), as a new release of WebODF right now does not make sense, given no real changes since 0.5.7 yet :)