### PR TITLE
Fix broken click-to-move in Chrome

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * Disable custom buttons save/saveAs/close/download when there is no session ([#893](https://github.com/kogmbh/WebODF/pull/893))
-
+* Fix chrome selections that cannot be collapsd by clicking inside them ([#905](https://github.com/kogmbh/WebODF/issues/905))
 
 # Changes between 0.5.6 and 0.5.7
 

--- a/webodf/lib/core/DomUtils.js
+++ b/webodf/lib/core/DomUtils.js
@@ -981,7 +981,7 @@
             var e = Object.create(null);
 
             // copy over all direct properties
-            Object.keys(/**@type{!Object}*/(event)).forEach(function (x) {
+            Object.keys(event.constructor.prototype).forEach(function (x) {
                 e[x] = event[x];
             });
             // only now set the prototype (might set properties read-only)


### PR DESCRIPTION
Chrome >=43 moves all properties available on objects of the DOM API them onto the prototype chain.  
See this recent announcement of the change: http://updates.html5rocks.com/2015/04/DOM-attributes-now-on-the-prototype.  
So while you can still access a coordinate of a `MouseEvent` instance like so: `mouseEvent.clientX`, the `clientX` property is now "non-enumerable", and even `mouseEvent.hasOwnProperty('clientX')` will return `false`.  
The new way of doing things is to then use `Object.keys(mouseEvent.constructor.prototype)`.

The iteration in `DomUtils.cloneEvent` is now done over the event's class prototype.
Fixes #905.