### PR TITLE
Make OdtDocument.getMemberIds return ALL memberIds

### DIFF
--- a/programs/editor/plugins/bella/Bella.js
+++ b/programs/editor/plugins/bella/Bella.js
@@ -84,6 +84,10 @@ define("webodf/editor/plugins/bella/Bella", [
                 ops = [];
 
             members.forEach(function (memberId) {
+                if (!odtDocument.getCursor(memberId)) {
+                    return;
+                }
+
                 var selection = odtDocument.getCursorSelection(memberId),
                     selectionType = odtDocument.getCursor(memberId).getSelectionType(),
                     op = new webodf.ops.OpMoveCursor();

--- a/programs/editor/plugins/bella/DocumentValidator.js
+++ b/programs/editor/plugins/bella/DocumentValidator.js
@@ -62,6 +62,7 @@ define("webodf/editor/plugins/bella/DocumentValidator", function() {
             var root = odtDocument.getRootNode(),
                 stepIterator = odtDocument.createStepIterator(root, 0, [odtDocument.getPositionFilter()], root);
 
+            // In a Bella environment each memberid has a cursor
             odtDocument.getMemberIds().forEach(function (memberId) {
                 var cursor = odtDocument.getCursor(memberId);
                 stepIterator.setPosition(cursor.getNode(), 0);

--- a/webodf/lib/gui/TrivialUndoManager.js
+++ b/webodf/lib/gui/TrivialUndoManager.js
@@ -504,7 +504,9 @@ gui.TrivialUndoManager = function TrivialUndoManager(defaultRules) {
         if (moved) {
             // Need to reset the odt document cursor list back to nil so new cursors are correctly re-registered
             document.getMemberIds().forEach(function (memberid) {
-                document.removeCursor(memberid);
+                if (document.hasCursor(memberid)) {
+                    document.removeCursor(memberid);
+                }
             });
             // Only do actual work if moveBackward does something to the undo stacks
             document.setDocumentElement(/**@type{!Element}*/(initialDoc.cloneNode(true)));

--- a/webodf/lib/ops/Document.js
+++ b/webodf/lib/ops/Document.js
@@ -91,6 +91,12 @@ ops.Document.prototype.createRootFilter = function (inputMemberId) { "use strict
  * @return {!core.PositionIterator}
  */
 ops.Document.prototype.createPositionIterator = function (rootNode) { "use strict"; };
+/**
+ * @param {!string} memberid
+ * @return {!boolean}
+ */
+ops.Document.prototype.hasCursor = function (memberid) { "use strict"; };
+
 /**@const*/
 ops.Document.signalCursorAdded =   "cursor/added";
 /**@const*/

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -30,7 +30,7 @@
      * of the given memberid, or a given node
      * @constructor
      * @implements {core.PositionFilter}
-     * @param {!string|!Node} anchor 
+     * @param {!string|!Node} anchor
      * @param {Object.<!ops.OdtCursor>} cursors
      * @param {function(!Node):!Node} getRoot
      */
@@ -186,7 +186,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         return /**@type{!Document}*/(self.getDocumentElement().ownerDocument);
     }
     this.getDOMDocument = getDOMDocument;
-    
+
     /**
      * @param {!Node} node
      * @return {!boolean}
@@ -818,15 +818,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
      * @return {!Array.<string>}
      */
     this.getMemberIds = function () {
-        var list = [],
-            /**@type{string}*/
-            i;
-        for (i in cursors) {
-            if (cursors.hasOwnProperty(i)) {
-                list.push(cursors[i].getMemberId());
-            }
-        }
-        return list;
+        return Object.keys(members);
     };
 
     /**

--- a/webodf/lib/ops/OdtDocument.js
+++ b/webodf/lib/ops/OdtDocument.js
@@ -815,6 +815,13 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     };
 
     /**
+     * @param {!string} memberid
+     * @return {!boolean}
+     */
+    this.hasCursor = function (memberid) {
+        return cursors.hasOwnProperty(memberid);
+    };
+    /**
      * @return {!Array.<string>}
      */
     this.getMemberIds = function () {

--- a/webodf/tests/gui/TrivialUndoManagerTests.js
+++ b/webodf/tests/gui/TrivialUndoManagerTests.js
@@ -32,11 +32,13 @@
 gui.TrivialUndoManagerTests = function TrivialUndoManagerTests(runner) {
     "use strict";
     var t, testarea,
-        r = runner;
+        r = runner,
+        member,
+        cursor;
 
-    function cursor(id) {
-        return { getMemberId: function () { return id; } };
-    }
+        cursor = member = function (id) {
+            return { getMemberId: function () { return id; } };
+        };
 
     /**
      * @param rootElement
@@ -61,10 +63,20 @@ gui.TrivialUndoManagerTests = function TrivialUndoManagerTests(runner) {
         this.setRootElement = noOp;
         this.setOdfContainer = noOp;
         this.cursors = [cursor("1")];
+        this.members = [member("1")];
         this.getMemberIds = function () {
-            return self.cursors.map(function (cursor) {
-                return cursor.getMemberId();
+            return self.members.map(function (member) {
+                return member.getMemberId();
             });
+        };
+        this.hasCursor = function (memberid) {
+            var i;
+            for (i = 0; i < self.cursors.length; i += 1) {
+                if (self.cursors[i].getMemberId() === memberid) {
+                    return true;
+                }
+            }
+            return false;
         };
         this.getDocumentElement = function () { return rootElement; };
         this.getRootNode = function () { return rootElement; };
@@ -195,6 +207,7 @@ gui.TrivialUndoManagerTests = function TrivialUndoManagerTests(runner) {
     }
 
     function setInitialState_AllCursorsMaintainedWhenCalledMultipleTimes() {
+        t.mock.members.push(member(2));
         t.mock.cursors.push(cursor(2));
         t.manager.onOperationExecuted(create(new ops.OpMoveCursor(), {timestamp: 1, memberid: 1}));
         t.manager.onOperationExecuted(create(new ops.OpMoveCursor(), {timestamp: 2, memberid: 2}));
@@ -362,6 +375,7 @@ gui.TrivialUndoManagerTests = function TrivialUndoManagerTests(runner) {
         t.manager.onOperationExecuted(create(new ops.OpMoveCursor(), {timestamp: 5, memberid: 1}));
         t.manager.onOperationExecuted(create(new ops.OpMoveCursor(), {timestamp: 6, memberid: 2}));
 
+        t.mock.members = [member(2)];
         t.mock.cursors = [cursor(2)];
         t.manager.initialize();
 

--- a/webodf/tests/manifest.json
+++ b/webodf/tests/manifest.json
@@ -216,6 +216,7 @@
         "odf.Namespaces",
         "odf.OdfCanvas",
         "odf.OdfNodeFilter",
+        "ops.Member",
         "ops.OdtCursor",
         "ops.OdtDocument",
         "xmldom.LSSerializer",

--- a/webodf/tests/ops/OdtDocumentTests.js
+++ b/webodf/tests/ops/OdtDocumentTests.js
@@ -558,7 +558,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
 
     function cursorPositionTests() {
         // Examples from README_cursorpositions.txt
-        
+
         return [
             // *************** Empty Paragraph *************** //
             // Examples from README_cursorpositions.txt
@@ -575,7 +575,7 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             // TODO behaviour is different from README_cursorpositions
             // "<text:p>  <text:span>|  </text:span> <text:span>  <text:span>  </text:span>  </text:span>  </text:p>",
 
-            
+
             // *************** Simple Text Nodes *************** //
             "<text:p>|A|B|C|</text:p>",
 
@@ -632,13 +632,23 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             '<text:p>|a|b|<office:annotation><text:list><text:list-item><text:p>|</text:p></text:list-item></text:list></office:annotation><text:span>|c|d|</text:span><office:annotation-end></office:annotation-end>1|2|</text:p>',
             '<text:p>|a|<html:div class="annotationWrapper"><office:annotation><text:list><text:list-item><text:p>|b|</text:p></text:list-item></text:list></office:annotation></html:div><html:span class="webodf-annotationHighlight">|c|</html:span><office:annotation-end></office:annotation-end>1|2|</text:p>',
             '<text:p>|a|<html:div class="annotationWrapper"><office:annotation><text:list><text:list-item><text:p>|b|</text:p></text:list-item></text:list></office:annotation></html:div><html:span class="webodf-annotationHighlight">|</html:span><office:annotation-end></office:annotation-end>1|2|</text:p>'
-            
+
         ].map(function(testInput) {
                 return {
                     name: "cursorPositions " + testInput,
                     f: testCursorPositions.bind(undefined, testInput)
                 };
             });
+    }
+
+    function testMemberIds() {
+        createOdtDocument('<text:p></text:p>');
+
+        t.odtDocument.addMember(new ops.Member('alice', /**@type{!ops.MemberProperties}*/({ fullName: 'Alice' })));
+        t.odtDocument.addMember(new ops.Member('bob', /**@type{!ops.MemberProperties}*/({ fullName: 'Bob' })));
+        t.odtDocument.addMember(new ops.Member('eve', /**@type{!ops.MemberProperties}*/({ fullName: 'Eve' })));
+
+        r.shouldBe(t, 't.odtDocument.getMemberIds().join()', '"alice,bob,eve"');
     }
 
     this.setUp = function () {
@@ -687,7 +697,9 @@ ops.OdtDocumentTests = function OdtDocumentTests(runner) {
             getTextNodeAtStep_At1_PutsTargetMemberCursor_BeforeTextNode,
             getTextNodeAtStep_At4_PutsTargetMemberCursor_BeforeTextNode,
             getTextNodeAtStep_AfterNonText_PutsTargetMemberCursor_BeforeTextNode,
-            getTextNodeAtStep_EmptyP_MovesAllCursors_BeforeTextNode
+            getTextNodeAtStep_EmptyP_MovesAllCursors_BeforeTextNode,
+
+            testMemberIds
         ]).concat(cursorPositionTests());
     };
     this.asyncTests = function () {


### PR DESCRIPTION
... and not just those of cursors. Surprised I never noticed this before.