### PR TITLE
A small script to help OfficeShots.org use WebODF for rendering.

### DIFF
--- a/programs/qtjsruntime/CMakeLists.txt
+++ b/programs/qtjsruntime/CMakeLists.txt
@@ -7,3 +7,5 @@ target_link_libraries(qtjsruntime
   Qt5::Network
   Qt5::PrintSupport
 )
+
+add_subdirectory(officeshots)

--- a/programs/qtjsruntime/officeshots/CMakeLists.txt
+++ b/programs/qtjsruntime/officeshots/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+COPY_FILES(OFFICESHOTSFILES ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+    index.html.in webodf-odf-to-exported.sh
+    )
+  
+add_custom_target(officeshotsDepencencies ALL DEPENDS ${OFFICESHOTSFILES})

--- a/programs/qtjsruntime/officeshots/index.html.in
+++ b/programs/qtjsruntime/officeshots/index.html.in
@@ -1,0 +1,32 @@
+<html>
+ <head>
+  <script src="$WEBODFJSPATH" type="text/javascript" charset="utf-8"></script>
+  <script type="text/javascript" charset="utf-8">
+    var canvas = null;
+
+    function exportToODF() {
+       console.log("exportToODF() top, canvas:" + canvas );
+       var container = canvas.odfContainer();
+       container.createByteArray(
+           function( zip ) { console.log("ok");
+               zip = runtime.byteArrayToString(zip, 'binary');
+               nativeio.writeFile("$THEODFOPUTPUTPATH", zip );
+           },
+           function( err ) { console.log("err"); }
+       );
+    }
+    
+    function init() {
+        var odfcanvas  = new odf.OdfCanvas(document.getElementById("odf"));
+        odfcanvas.load("$THEODFFILEPATH");
+	canvas = odfcanvas;
+	if( $EXPORTODF ) {
+            setTimeout( exportToODF, 100 );
+        }	
+    }
+  </script>
+ </head>
+ <body onLoad="init()">
+  <div id="odf"></div>
+ </body>
+</html>

--- a/programs/qtjsruntime/officeshots/webodf-odf-to-exported.sh
+++ b/programs/qtjsruntime/officeshots/webodf-odf-to-exported.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+#
+# webodf-odf-to-exported.sh a script to convert from ODF files to
+# various output formats for OfficeShots.org
+#
+# Usage:
+#   webodf-odf-to-exported.sh input.odt output.pdf
+#
+# The output format is detected from the output filename
+#
+# Note that --help and --version are used by the OfficeShots code
+# to detect this script so these options should exist.
+#
 
 if [ y"$1" == "y--help" -o y"$1" == "y--version" ]; then
     echo "WebODF conversion tool webodf-odf-to-exported.sh"
@@ -17,6 +29,8 @@ export THEODFOPUTPUTPATH="$outpath"
 
 [[ $outpath == *.pdf ]] && format=pdf
 if [[ $outpath == *.odt ]]; then
+    # writing back to an odt file still produces
+    # a pdf output as a side effect.
     format=pdf
     EXPORTODF=1
     outpath="$outpath.pdf"

--- a/programs/qtjsruntime/officeshots/webodf-odf-to-exported.sh
+++ b/programs/qtjsruntime/officeshots/webodf-odf-to-exported.sh
@@ -29,4 +29,4 @@ cat "$SCRIPTDIR/index.html.in" | envsubst >| /tmp/thepage.html
 
 echo $QTJSRUNTIME --export-$format $outpath /tmp/thepage.html
 $QTJSRUNTIME --export-$format $outpath /tmp/thepage.html
-
+exit 0

--- a/programs/qtjsruntime/officeshots/webodf-odf-to-exported.sh
+++ b/programs/qtjsruntime/officeshots/webodf-odf-to-exported.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ y"$1" == "y--help" -o y"$1" == "y--version" ]; then
+    echo "WebODF conversion tool webodf-odf-to-exported.sh"
+    echo "Version 0.1"
+    exit
+fi
+inpath=${1:?supply input ODT file path as arg1};
+outpath=${2:?supply output file path as arg2};
+format=${3:-png};
+EXPORTODF=0
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+QTJSRUNTIME="$SCRIPTDIR/../qtjsruntime"
+
+export THEODFOPUTPUTPATH="$outpath"
+
+[[ $outpath == *.pdf ]] && format=pdf
+if [[ $outpath == *.odt ]]; then
+    format=pdf
+    EXPORTODF=1
+    outpath="$outpath.pdf"
+fi    
+    
+export THEODFFILEPATH="$inpath"
+export WEBODFJSPATH="$SCRIPTDIR/../../../webodf/webodf.js"
+export EXPORTODF
+cat "$SCRIPTDIR/index.html.in" | envsubst >| /tmp/thepage.html
+
+echo $QTJSRUNTIME --export-$format $outpath /tmp/thepage.html
+$QTJSRUNTIME --export-$format $outpath /tmp/thepage.html
+


### PR DESCRIPTION
Hi,
  Please let me know if there is a better way to do this. This PR allows OfficeShots to use WebODF for png, pdf, and round trip odf conversion of files. There is some detection on the Officeshots side that I'll also commit there. Round trip was a little hairy as I used the javascript API directly in the page to perform the document saving. I assume one could use the WebODF API from Qt as well, though the below method works for me.

  Ultimately it would be good to extend things to allow which browser to use to be stipulated. But using qtjsruntime is a good start IMHO. The webodf-odf-to-exported.sh script is designed to be able to find the webodf.js file and qtjsruntime for itself and thus be directly executed from the build directory.
