### PR TITLE
If there is no <office:settings/> element, save an empty <office:document-settings/> element.

### DIFF
--- a/webodf/lib/odf/OdfContainer.js
+++ b/webodf/lib/odf/OdfContainer.js
@@ -993,18 +993,15 @@
          * @return {!string}
          */
         function serializeSettingsXml() {
-            var serializer,
+            var serializer = new xmldom.LSSerializer(),
                 /**@type{!string}*/
-                s = "";
+                s = createDocumentElement("document-settings");
             // <office:settings/> is optional, but if present must have at least one child element
             if (self.rootElement.settings && self.rootElement.settings.firstElementChild) {
-                serializer = new xmldom.LSSerializer();
-                s = createDocumentElement("document-settings");
                 serializer.filter = new odf.OdfNodeFilter();
                 s += serializer.writeToString(self.rootElement.settings, odf.Namespaces.namespaceMap);
-                s += "</office:document-settings>";
             }
-            return s;
+            return s + "</office:document-settings>";
         }
         /**
          * @return {!string}
@@ -1306,8 +1303,8 @@
                 date = new Date(),
                 settings;
 
-            settings = serializeSettingsXml();
-            if (settings) {
+            if (partMimetypes["settings.xml"]) {
+                settings = serializeSettingsXml();
                 // Optional according to package spec
                 // See http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__440346_826425813
                 data = runtime.byteArrayFromString(settings, "utf8");

--- a/webodf/tests/odf/OdfContainerTests.js
+++ b/webodf/tests/odf/OdfContainerTests.js
@@ -195,9 +195,7 @@ odf.OdfContainerTests = function OdfContainerTests(runner) {
             t.odf = new odf.OdfContainer(path, function (odf) {
                 t.odf = odf;
                 r.shouldBe(t, "t.odf.state", "odf.OdfContainer.DONE");
-                // The value would only become null if it was a node. By default, random unspecified
-                // attributes on anything are undefined.
-                r.shouldBe(t, "t.odf.rootElement.settings", "undefined");
+                r.shouldBe(t, "t.odf.rootElement.settings", "null");
                 checkMimeType(t, path, callback);
             });
         });


### PR DESCRIPTION
I ran the tests, but did not create a new test. Also tested in wodo editor.