### PR TITLE
Add support for fo:font-variant

### DIFF
--- a/webodf/lib/odf/Style2CSS.js
+++ b/webodf/lib/odf/Style2CSS.js
@@ -124,7 +124,8 @@ odf.Style2CSS = function Style2CSS() {
             // this sets the element background, not just the text background
             [ fons, 'background-color', 'background-color' ],
             [ fons, 'font-weight', 'font-weight' ],
-            [ fons, 'font-style', 'font-style' ]
+            [ fons, 'font-style', 'font-style' ],
+            [ fons, 'font-variant', 'font-variant' ]
         ],
 
         /**@const


### PR DESCRIPTION
Is a simple direct mapping to CSS.
Found in ODF plugfest, test with http://www.vandenoever.info/tmp/2015/sep/text-properties-results/input/odt-font-variant-small-caps_1.2.odt