### PR TITLE
Add fo:letter-spacing support

### DIFF
--- a/webodf/lib/odf/Style2CSS.js
+++ b/webodf/lib/odf/Style2CSS.js
@@ -125,7 +125,8 @@ odf.Style2CSS = function Style2CSS() {
             [ fons, 'background-color', 'background-color' ],
             [ fons, 'font-weight', 'font-weight' ],
             [ fons, 'font-style', 'font-style' ],
-            [ fons, 'font-variant', 'font-variant' ]
+            [ fons, 'font-variant', 'font-variant' ],
+            [ fons, 'letter-spacing', 'letter-spacing' ]
         ],
 
         /**@const


### PR DESCRIPTION
Found in ODF plugfest, is a direct mapping.

Test with:
http://www.vandenoever.info/tmp/2015/sep/text-properties-results/input/odt-letter-spacing-1mm_1.2.odt
and 
http://www.vandenoever.info/tmp/2015/sep/text-properties-results/input/odt-letter-spacing--1mm_1.2.odt